### PR TITLE
run_id

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,8 @@ Earthquake source parameters from S-wave displacement spectra
   - Write SourceSpec version and run complete time to SQLite file
   - Write author and agency info (if specified) to output files, figures and
     HTML report
+  - Command line option `--run-id` to provide a string identifying the
+    current run (see pull request [#6][])
 
 - Improvements:
   - Use travel time (from NonLinLoc grid, "iasp91" model or `vs_tt`) to compute
@@ -90,7 +92,7 @@ Note that v1.5 is no more compatible with Python 2!
     parameter, named `clip_max_percent`)
     - Check for trace clipping only in the processing window
     - Use histogram of samples to detect clipping
-  - Fix for wrong component used for 'SV' spectra (#3)
+  - Fix for wrong component used for 'SV' spectra (see issue [#3][])
 - Inversion:
   - New config option: `Mw_0_variability`. Allowed variability around `Mw_0`
     during the main inversion. Previously hardcoded to 0.1
@@ -303,3 +305,7 @@ Extended and generalized for the CRL application.
 ## v0.1 - 2012-01-17
 
 Initial Python port.
+
+
+[#3]: https://github.com/SeismicSource/sourcespec/issues/3
+[#6]: https://github.com/SeismicSource/sourcespec/issues/6

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -3,3 +3,4 @@ Emanuela Matrullo
 Agnès Chounet
 Tony Alfredo Stabile
 Sophie Lambotte
+Kris Vanneste

--- a/sourcespec/html_report_template/index.html
+++ b/sourcespec/html_report_template/index.html
@@ -127,6 +127,12 @@
               <th scope="row">Event ID:</th>
               <td>{EVENTID}</td>
             </tr>
+{RUNID_COMMENT_BEGIN}
+            <tr>
+              <th scope="row">Run ID:</th>
+              <td>{RUNID}</td>
+            </tr>
+{RUNID_COMMENT_END}
             <tr>
               <th scope="row">Longitude:</th>
               <td>{EVENT_LONGITUDE} °E</td>

--- a/sourcespec/ssp_html_report.py
+++ b/sourcespec/ssp_html_report.py
@@ -248,6 +248,7 @@ def html_report(config, sourcepar):
     # Output files and maps
     hypo = config.hypo
     evid = hypo.evid
+    run_id = config.options.run_id
     config_file = '{}.ssp.conf'.format(evid)
     out_file = '{}.ssp.out'.format(evid)
     log_file = '{}.ssp.log'.format(evid)
@@ -364,6 +365,7 @@ def html_report(config, sourcepar):
         '{AUTHOR}': author,
         '{AGENCY}': agency,
         '{EVENTID}': evid,
+        '{RUNID}': run_id,
         '{EVENT_LONGITUDE}': '{:8.3f}'.format(hypo.longitude),
         '{EVENT_LATITUDE}': '{:7.3f}'.format(hypo.latitude),
         '{EVENT_DEPTH}': '{:5.1f}'.format(hypo.depth),
@@ -424,6 +426,18 @@ def html_report(config, sourcepar):
         '{BOX_PLOTS}': box_plots,
         '{STATION_TABLE_ROWS}': station_table_rows,
     }
+
+    # Only show Run ID if it is not empty
+    if run_id:
+        run_id_comment_begin = ''
+        run_id_comment_end = ''
+    else:
+        run_id_comment_begin = '<!--'
+        run_id_comment_end = '-->'
+    replacements.update({
+        '{RUNID_COMMENT_BEGIN}': run_id_comment_begin,
+        '{RUNID_COMMENT_END}': run_id_comment_end
+    })
 
     # Misfit plots (when using grid search)
     if os.path.exists(os.path.join(config.options.outdir, 'misfit')):

--- a/sourcespec/ssp_output.py
+++ b/sourcespec/ssp_output.py
@@ -256,9 +256,12 @@ def _write_parfile(config, sourcepar):
     parfile.write('\n*** Run completed on: {} {}'.format(now, timezone))
     config.end_of_run = now
     config.end_of_run_tz = timezone
+    if config.options.run_id:
+        parfile.write('\n*** Run ID: {}'.format(config.options.run_id))
     _write_author_and_agency_to_parfile(config, parfile)
 
     parfile.close()
+
     logger.info('Output written to file: ' + parfilename)
 
 

--- a/sourcespec/ssp_output.py
+++ b/sourcespec/ssp_output.py
@@ -284,7 +284,7 @@ def _write_db(config, sourcepar):
 
     hypo = config.hypo
     evid = hypo.evid
-    runid = config.get('run_id', '')
+    runid = config.options.run_id
 
     # Open SQLite database
     conn = sqlite3.connect(database_file, timeout=60)

--- a/sourcespec/ssp_output.py
+++ b/sourcespec/ssp_output.py
@@ -284,6 +284,7 @@ def _write_db(config, sourcepar):
 
     hypo = config.hypo
     evid = hypo.evid
+    runid = config.get('run_id', '')
 
     # Open SQLite database
     conn = sqlite3.connect(database_file, timeout=60)
@@ -292,7 +293,7 @@ def _write_db(config, sourcepar):
     # Init Station table
     c.execute(
         'create table if not exists Stations '
-        '(stid, evid,'
+        '(stid, evid, runid,'
         'Mo, Mo_err_minus, Mo_err_plus,'
         'Mw, Mw_err_minus, Mw_err_plus,'
         'fc, fc_err_minus, fc_err_plus,'
@@ -308,11 +309,11 @@ def _write_db(config, sourcepar):
         nobs += 1
         par = stationpar[statId]
         # Remove existing line, if present
-        t = (statId, evid)
-        c.execute('delete from Stations where stid=? and evid=?;', t)
+        t = (statId, evid, runid)
+        c.execute('delete from Stations where stid=? and evid=? and runid=?;', t)
         # Insert new line
         t = (
-            statId, evid,
+            statId, evid, runid,
             par['Mo'], *par['Mo_err'],
             par['Mw'], *par['Mw_err'],
             par['fc'], *par['fc_err'],
@@ -335,7 +336,7 @@ def _write_db(config, sourcepar):
     # Init Event table
     c.execute(
         'create table if not exists Events '
-        '(evid, orig_time, lon, lat, depth, nobs,'
+        '(evid, runid, orig_time, lon, lat, depth, nobs,'
         'Mo, Mo_err_minus, Mo_err_plus,'
         'Mo_wavg, Mo_wavg_err_minus, Mo_wavg_err_plus,'
         'Mw, Mw_err, Mw_wavg, Mw_wavg_err,'
@@ -361,10 +362,10 @@ def _write_db(config, sourcepar):
     run_completed = '{} {}'.format(config.end_of_run, config.end_of_run_tz)
     ssp_version = get_versions()['version']
     # Remove event from Event table, if present
-    t = (evid, )
-    c.execute('delete from Events where evid=?;', t)
+    t = (evid, runid)
+    c.execute('delete from Events where evid=? and runid=?;', t)
     t = (
-        evid,
+        evid, runid,
         str(hypo.origin_time),
         float(hypo.longitude), float(hypo.latitude), float(hypo.depth),
         nobs,

--- a/sourcespec/ssp_parse_arguments.py
+++ b/sourcespec/ssp_parse_arguments.py
@@ -142,6 +142,12 @@ def _update_parser(parser, progname):
             help='save output to OUTDIR (default: sspec_out)',
             metavar='OUTDIR'
         )
+        parser.add_argument(
+            '-r', '--run_id', dest='run_id',
+            action='store', default='',
+            help='string identifying current run (default: "")',
+            metavar='RUN_ID'
+        )
     elif progname == 'source_model':
         parser.add_argument(
             '-f', '--fmin', dest='fmin', action='store',

--- a/sourcespec/ssp_setup.py
+++ b/sourcespec/ssp_setup.py
@@ -482,7 +482,9 @@ def move_outdir(config):
     src = config.options.outdir
     run_id = config.options.run_id
     path = os.path.normpath(config.options.outdir).split(os.sep)
-    dst = os.path.join(*path[:-1], str(evid) + '_' + run_id)
+    dst = os.path.join(*path[:-1], str(evid))
+    if run_id:
+        dst += '_' + run_id
     # Create destination
     if not os.path.exists(dst):
         os.makedirs(dst)

--- a/sourcespec/ssp_setup.py
+++ b/sourcespec/ssp_setup.py
@@ -480,7 +480,7 @@ def move_outdir(config):
     except Exception:
         return
     src = config.options.outdir
-    run_id = config.get('run_id', '')
+    run_id = config.options.run_id
     path = os.path.normpath(config.options.outdir).split(os.sep)
     dst = os.path.join(*path[:-1], str(evid) + '_' + run_id)
     # Create destination

--- a/sourcespec/ssp_setup.py
+++ b/sourcespec/ssp_setup.py
@@ -474,14 +474,15 @@ def save_config(config):
 
 
 def move_outdir(config):
-    """Move outdir to a new dir named from evid."""
+    """Move outdir to a new dir named from evid (and optional run_id)."""
     try:
         evid = config.hypo.evid
     except Exception:
         return
     src = config.options.outdir
+    run_id = config.get('run_id', '')
     path = os.path.normpath(config.options.outdir).split(os.sep)
-    dst = os.path.join(*path[:-1], evid)
+    dst = os.path.join(*path[:-1], str(evid) + '_' + run_id)
     # Create destination
     if not os.path.exists(dst):
         os.makedirs(dst)


### PR DESCRIPTION
This feature branch adds a --run-id command-line argument to source_spec. The run_id is used to name the output folder and is also added in a dedicated field in the database. This allows running source_spec with different configurations for the same event without overwriting the corresponding results.