### PR TITLE
P wave type

### DIFF
--- a/sourcespec/configspec.conf
+++ b/sourcespec/configspec.conf
@@ -223,6 +223,8 @@ NLL_model_dir = string(default=None)
 rho = float(default=2500)
 # S-wave average radiation pattern coefficient:
 rps = float(default=0.62)
+# P-wave average radiation pattern coefficient:
+rpp = float(default=0.52)
 # Radiation pattern from focal mechanism, if available
 rps_from_focal_mechanism = boolean(default=False)
 

--- a/sourcespec/ssp_data_types.py
+++ b/sourcespec/ssp_data_types.py
@@ -94,11 +94,12 @@ class Bounds(object):
 
     def _Qo_to_t_star(self):
         # See if there is a travel-time vs defined
-        vs = self.config.vs_tt
-        if vs is None:
-            vs = self.config.hypo.vs
+        if self.config.wave_type[0] == 'S':
+            v = self.config.vs_tt or self.config.hypo.vs
+        elif self.config.wave_type[0] == 'P':
+            v = self.config.vp_tt or self.config.hypo.vp
         t_star_bounds =\
-            self.hd/(vs*np.array(self.config.Qo_min_max))
+            self.hd/(v*np.array(self.config.Qo_min_max))
         return sorted(t_star_bounds)
 
     def _fix_initial_values_t_star(self):

--- a/sourcespec/ssp_inversion.py
+++ b/sourcespec/ssp_inversion.py
@@ -268,8 +268,10 @@ def _spec_inversion(config, spec, noise_weight):
 
     # additional parameters, computed from fc, Mw and t_star
     vs = config.hypo.vs
+    vp = config.hypo.vp
     # See if there is a travel-time vs defined
     vs_tt = config.vs_tt or vs
+    vp_tt = config.vp_tt or vp
     # seismic moment
     par['Mo'] = mag_to_moment(par['Mw'])
     # source radius in meters
@@ -277,7 +279,10 @@ def _spec_inversion(config, spec, noise_weight):
     # Brune stress drop in MPa
     par['bsd'] = bsd(par['Mo'], par['ra'])
     # quality factor
-    par['Qo'] = quality_factor(par['hyp_dist'], vs_tt, par['t_star'])
+    if config.wave_type[0] == 'S':
+        par['Qo'] = quality_factor(par['hyp_dist'], vs_tt, par['t_star'])
+    elif config.wave_type[0] == 'P':
+        par['Qo'] = quality_factor(par['hyp_dist'], vp_tt, par['t_star'])
 
     # Check post-inversion bounds for bsd
     pi_bsd_min, pi_bsd_max = config.pi_bsd_min_max or (-np.inf, np.inf)
@@ -290,8 +295,10 @@ def _spec_inversion(config, spec, noise_weight):
     par_err = OrderedDict(zip(params_name, params_err))
     # additional parameter errors, computed from fc, Mw and t_star
     vs = config.hypo.vs
+    vp = config.hypo.vp
     # See if there is a travel-time vs defined
     vs_tt = config.vs_tt or vs
+    vp_tt = config.vp_tt or vp
     # seismic moment
     Mw_min = par['Mw'] - par_err['Mw'][0]
     Mw_max = par['Mw'] + par_err['Mw'][1]
@@ -315,8 +322,12 @@ def _spec_inversion(config, spec, noise_weight):
     if t_star_min <= 0:
         t_star_min = 0.001
     t_star_max = par['t_star'] + par_err['t_star'][1]
-    Qo_min = quality_factor(par['hyp_dist'], vs_tt, t_star_max)
-    Qo_max = quality_factor(par['hyp_dist'], vs_tt, t_star_min)
+    if config.wave_type[0] == 'S':
+        Qo_min = quality_factor(par['hyp_dist'], vs_tt, t_star_max)
+        Qo_max = quality_factor(par['hyp_dist'], vs_tt, t_star_min)
+    elif config.wave_type[0] == 'P':
+        Qo_min = quality_factor(par['hyp_dist'], vp_tt, t_star_max)
+        Qo_max = quality_factor(par['hyp_dist'], vp_tt, t_star_min)
     par_err['Qo'] = (par['Qo']-Qo_min, Qo_max-par['Qo'])
 
     return par, par_err

--- a/sourcespec/ssp_plot_traces.py
+++ b/sourcespec/ssp_plot_traces.py
@@ -176,10 +176,14 @@ def _plot_trace(config, trace, ntraces, tmax,
         ax.add_patch(rect)
     except KeyError:
         pass
-    # S-wave window
-    S1 = trace.stats.arrivals['S1'][1] - trace.stats.starttime
-    S2 = trace.stats.arrivals['S2'][1] - trace.stats.starttime
-    rect = patches.Rectangle((S1, 0), width=S2-S1, height=1,
+    # Signal window
+    if config.wave_type[0] == 'S':
+        t1 = trace.stats.arrivals['S1'][1] - trace.stats.starttime
+        t2 = trace.stats.arrivals['S2'][1] - trace.stats.starttime
+    elif config.wave_type[0] == 'P':
+        t1 = trace.stats.arrivals['P1'][1] - trace.stats.starttime
+        t2 = trace.stats.arrivals['P2'][1] - trace.stats.starttime
+    rect = patches.Rectangle((t1, 0), width=t2-t1, height=1,
                              transform=trans, color='yellow',
                              alpha=0.5, zorder=-1)
     ax.add_patch(rect)

--- a/sourcespec/ssp_process_traces.py
+++ b/sourcespec/ssp_process_traces.py
@@ -104,8 +104,12 @@ def _check_sn_ratio(config, trace):
     trace_cutS.detrend(type='constant')
     # ...and the linear trend...
     trace_cutS.detrend(type='linear')
-    t1 = trace_cutS.stats.arrivals['S1'][1]
-    t2 = trace_cutS.stats.arrivals['S2'][1]
+    if config.wave_type[0] == 'S':
+        t1 = trace_cutS.stats.arrivals['S1'][1]
+        t2 = trace_cutS.stats.arrivals['S2'][1]
+    elif config.wave_type[0] == 'P':
+        t1 = trace_cutS.stats.arrivals['P1'][1]
+        t2 = trace_cutS.stats.arrivals['P2'][1]
     trace_cutS.trim(starttime=t1, endtime=t2, pad=True, fill_value=0)
     rmsnoise2 = np.power(trace_noise.data, 2).sum()
     rmsnoise = np.sqrt(rmsnoise2)
@@ -184,11 +188,15 @@ def _merge_stream(config, st):
             raise RuntimeError(msg)
     # Then, compute the same statisics for the S-wave window.
     st_cut = st.copy()
-    t1 = st[0].stats.arrivals['S1'][1]
-    t2 = st[0].stats.arrivals['S2'][1]
+    if config.wave_type[0] == 'S':
+        t1 = st[0].stats.arrivals['S1'][1]
+        t2 = st[0].stats.arrivals['S2'][1]
+    elif config.wave_type[0] == 'P':
+        t1 = st[0].stats.arrivals['P1'][1]
+        t2 = st[0].stats.arrivals['P2'][1]
     st_cut.trim(starttime=t1, endtime=t2)
     if not st_cut:
-        msg = '{}: No signal for the selected S-wave cut interval: '
+        msg = '{}: No signal for the selected %c-wave cut interval: ' % config.wave_type[0]
         msg += 'skipping trace >\n'
         msg += '> Cut interval: {} - {}'
         msg = msg.format(traceid, t1, t2)
@@ -249,11 +257,16 @@ def _add_hypo_dist_and_arrivals(config, st):
             msg = '{}: Unable to get S arrival time: skipping trace'
             msg = msg.format(trace.id)
             raise RuntimeError(msg)
-        # Signal window for spectral analysis
+        # Signal window for spectral analysis (S phase)
         t1 = s_arrival_time - config.pre_s_time
         t2 = t1 + config.win_length
         trace.stats.arrivals['S1'] = ('S1', t1)
         trace.stats.arrivals['S2'] = ('S2', t2)
+        # Signal window for spectral analysis (P phase)
+        t1 = p_arrival_time - config.pre_s_time
+        t2 = t1 + min(config.win_length, s_arrival_time-p_arrival_time)
+        trace.stats.arrivals['P1'] = ('P1', t1)
+        trace.stats.arrivals['P2'] = ('P2', t2)
         # Noise window for spectral analysis
         t1 = p_arrival_time - config.pre_p_time
         t2 = t1 + config.win_length

--- a/sourcespec/ssp_radiation_pattern.py
+++ b/sourcespec/ssp_radiation_pattern.py
@@ -85,15 +85,21 @@ rps_cache = dict()
 
 def get_radiation_pattern_coefficient(stats, config):
     if not config.rps_from_focal_mechanism:
-        return config.rps
+        if config.wave_type[0] == 'S':
+            return config.rps
+        elif config.wave_type[0] == 'P':
+            return config.rpp
     try:
         strike = stats.hypo.strike
         dip = stats.hypo.dip
         rake = stats.hypo.rake
     except Exception:
         logger.warning(
-            'Cannot find focal mechanism. Using "rps" value from config file')
-        return config.rps
+            'Cannot find focal mechanism. Using "rp[p/s]" value from config file')
+        if config.wave_type[0] == 'S':
+            return config.rps
+        elif config.wave_type[0] == 'P':
+            return config.rpp
     traceid = '.'.join(
         (stats.network, stats.station, stats.location, stats.channel))
     wave = config.wave_type
@@ -105,7 +111,7 @@ def get_radiation_pattern_coefficient(stats, config):
     except KeyError:
         pass
     try:
-        takeoff_angle = stats.takeoff_angles['S']
+        takeoff_angle = stats.takeoff_angles[config.wave_type[0]]
     except Exception:
         logger.warning(
             '{}: Cannot find takeoff angle. '


### PR DESCRIPTION
This feature branch implements inversion of P-wave spectra:
- Added 'rpp' configuration parameter for average P-wave radiation coefficient in sourcespec.conf.
- Start and end time of the P-window are computed, making sure it does not overlap with the S phase, and stored in the trace headers (in ssp_process_traces.py).
- Selection of P/S-window based on config.wave_type for computing spectra (in ssp_process_traces.py and ssp_build_spectra.py) and plotting the traces (ssp_plot_traces.py).
- Selection of Z-component only for P-wave spectra (in ssp_build_spectra.py).
- Selection of average P/S radiation coefficient or of P/S takeoff angle (when using focal mechanism) based on config.wave_type (in ssp_radiation_pattern.py).
- Selection of P/S velocities based on config.wave_type to convert displacement to moment (in ssp_build_spectra.py).
- Selection of P/S velocities based on config.wave_type to compute quality factor (in ssp_inversion.py) and to determine bounds on t_star from Qo bounds (in ssp_data_types.py).
