### PR TITLE
P wave type (version 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # SourceSpec
 
-Earthquake source parameters from S-wave displacement spectra
+Earthquake source parameters from P- or S-wave displacement spectra
 
 (c) 2011-2022 Claudio Satriano <satriano@ipgp.fr>
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ Earthquake source parameters from S-wave displacement spectra
   - Config options `vp` and `vs` have been renamed to `vp_source`
     and `vs_source` (see issue [#5])
   - New, optional, config options `vp_stations` and `vs_stations`
+  - Config options `pre_p_time` and `pre_s_time` have been renamed to
+    `noise_pre_time` and `signal_pre_time`, respectively (see pull request [#9])
   - Config parameters `PLOT_SHOW`, `PLOT_SAVE` and `PLOT_SAVE_FORMAT` are now
     lowercase (`plot_show`, `plot_save` and `plot_save_format`)
   - New, optional, general config parameters for specyfing author and agency
@@ -310,3 +312,4 @@ Initial Python port.
 [#3]: https://github.com/SeismicSource/sourcespec/issues/3
 [#5]: https://github.com/SeismicSource/sourcespec/issues/5
 [#6]: https://github.com/SeismicSource/sourcespec/issues/6
+[#9]: https://github.com/SeismicSource/sourcespec/issues/9

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ Earthquake source parameters from P- or S-wave displacement spectra
     section called `TRACE AND METADATA PARAMETERS`
 
 - Features:
+  - Support for P-wave spectral inversion (see pull request [#9])
   - It is now possible to provide different vp and vs velocities, close to the
     source and close to the stations (see the new config options above and
     issue [#5])

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,8 @@ Earthquake source parameters from P- or S-wave displacement spectra
   - New, optional, config options `vp_stations` and `vs_stations`
   - Config options `pre_p_time` and `pre_s_time` have been renamed to
     `noise_pre_time` and `signal_pre_time`, respectively (see pull request [#9])
+  - Config parameter `rps_from_focal_mechanism` renamed to
+    `rp_from_focal_mechanism` (see pull request [#9])
   - Config parameters `PLOT_SHOW`, `PLOT_SAVE` and `PLOT_SAVE_FORMAT` are now
     lowercase (`plot_show`, `plot_save` and `plot_save_format`)
   - New, optional, general config parameters for specyfing author and agency

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -4,6 +4,6 @@ authors:
 - family-names: "Satriano"
   given-names: "Claudio"
   orcid: "https://orcid.org/0000-0002-3039-2530"
-title: "SourceSpec – Earthquake source parameters from S-wave displacement spectra"
+title: "SourceSpec – Earthquake source parameters from P- or S-wave displacement spectra"
 doi: 10.5281/ZENODO.3688587
 url: "https://sourcespec.seismicsource.org"

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # SourceSpec
 
-Earthquake source parameters from S-wave displacement spectra
+Earthquake source parameters from P- or S-wave displacement spectra
 
 [![PyPI-badge]][PyPI-link]
 [![license-badge]][license-link]
@@ -97,8 +97,9 @@ repository.
 
 If you used SourceSpec for a scientific paper, please cite it as:
 
-> Satriano, C. (2022). SourceSpec – Earthquake source parameters from S-wave
-> displacement spectra (X.Y). https://doi.org/10.5281/ZENODO.3688587
+> Satriano, C. (2022). SourceSpec – Earthquake source parameters from
+> P- or S-wave displacement spectra (X.Y).
+> https://doi.org/10.5281/ZENODO.3688587
 
 Please replace `X.Y` with the SourceSpec version number you used.
 

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -9,17 +9,17 @@ SourceSpec documentation
 SourceSpec is a collection of command line programs (written in Python) to
 determine earthquake source parameters (seismic moment :math:`M_0`, corner
 frequency :math:`f_c`) and the inelastic attenuation term (:math:`t^*`), from
-the modeling of waveform spectra.
+the modeling of waveform displacement spectra.
 
 Other parameters (source radius :math:`r_0`, stress drop :math:`\Delta \sigma`)
-are computed from the inverted ones. The quality factor :math:`Q` is determined
-from :math:`t^*`.
+are computed from the inverted ones. The quality factor :math:`Q_0` is
+determined from :math:`t^*`.
 
 As a bonus, local magnitude :math:`M_l` is computed as well.
 
 SourceSpec is composed of the following programs:
 
-* ``source_spec``: inverts the S-wave displacement spectra from station
+* ``source_spec``: inverts the P- or S-wave displacement spectra from station
   recordings of a single event.
 * ``ssp_residuals``: computes station residuals from ``source_spec`` output.
 * ``source_model``: direct spectral modelling.

--- a/doc/source_spec.rst
+++ b/doc/source_spec.rst
@@ -4,7 +4,7 @@
 SourceSpec
 ###########
 
-Earthquake source parameters from inversion of S-wave spectra.
+Earthquake source parameters from inversion of P- or S-wave spectra.
 
 :copyright:
     2011-2022 Claudio Satriano <satriano@ipgp.fr>
@@ -15,7 +15,7 @@ Earthquake source parameters from inversion of S-wave spectra.
 Overview
 ========
 
-``source_spec`` inverts the S-wave displacement spectra from
+``source_spec`` inverts the P- or S-wave displacement spectra from
 station recordings of a single event.
 
 Spectral model
@@ -31,7 +31,7 @@ propagation term (geometric and anelastic attenuation of body waves):
           \frac{1}{r}
           \times
           \frac{2 R_{\Theta\Phi}}
-               {4 \pi \rho_h^{1/2} \rho_r^{1/2} \beta_h^{5/2} \beta_r^{1/2}}
+               {4 \pi \rho_h^{1/2} \rho_r^{1/2} c_h^{5/2} c_r^{1/2}}
           \times
           M_O
           \times
@@ -43,11 +43,11 @@ where:
 
 - :math:`r` is the hypocentral distance (:math:`\frac{1}{r}` is geometric
   attenuation);
-- :math:`R_{\Theta\Phi}` is the radiation pattern coefficient for S-waves
+- :math:`R_{\Theta\Phi}` is the radiation pattern coefficient for P- or S-waves
   (average or computed from focal mechanism, if available);
 - :math:`\rho_h` and :math:`\rho_r` are the medium densities at the hypocenter
   and at the receiver, respectively;
-- :math:`\beta_h` and :math:`\beta_r` are the S-wave velocities at the hypocenter
+- :math:`c_h` and :math:`c_r` are the P- or S-wave velocities at the hypocenter
   and at the receiver, respectively;
 - :math:`M_O` is the seismic moment;
 - :math:`f` is the frequency;
@@ -66,7 +66,7 @@ and convert them to seismic moment units:
 
    M(f) \equiv
    r \times
-   \frac{4 \pi \rho_h^{1/2} \rho_r^{1/2} \beta_h^{5/2} \beta_r^{1/2}}
+   \frac{4 \pi \rho_h^{1/2} \rho_r^{1/2} c_h^{5/2} c_r^{1/2}}
         {2 R_{\Theta\Phi}}
    \times S(f) =
           M_O \times
@@ -120,14 +120,15 @@ where :math:`M_w \equiv \frac{2}{3} (\log_{10} M_0 - 9.1)`.
 
 The parameters to determine are :math:`M_w`, :math:`f_c` and :math:`t^*`.
 
-The retrieved attenuation parameter :math:`t^*` is then converted to the S-wave
-quality factor :math:`Q_0` using the following expression:
+The retrieved attenuation parameter :math:`t^*` is then converted to the P- or
+S-wave quality factor :math:`Q_0^{[P|S]}` using the following expression:
 
 .. math::
 
-   Q_0 = \frac{tt_S(r)}{t^*}
+   Q_0^{[P|S]} = \frac{tt_{[P|S]}(r)}{t^*}
 
-where :math:`tt_S(r)` is the S-wave travel time from source to station.
+where :math:`tt_{[P|S]}(r)` is the P- or S-wave travel time from source to
+station.
 
 Station-specific effects can be determined by running ``source_spec`` on several
 events and computing the average of station residuals between observed and

--- a/sourcespec/configspec.conf
+++ b/sourcespec/configspec.conf
@@ -136,7 +136,7 @@ taper_halfwidth = float(0, 0.5, default=0.05)
 # this window length, so that the spectral
 # sampling is fixed to 1/spectral_win_length.
 # Comment out (or set to None) to use
-# S-wave window as spectral window length.
+# signal window as spectral window length.
 spectral_win_length = float(default=None)
 
 # Spectral smoothing window width in frequency decades

--- a/sourcespec/configspec.conf
+++ b/sourcespec/configspec.conf
@@ -219,12 +219,12 @@ vs_stations = float(default=None)
 NLL_model_dir = string(default=None)
 # Density (kg/m3):
 rho = float(default=2500)
-# S-wave average radiation pattern coefficient:
-rps = float(default=0.62)
 # P-wave average radiation pattern coefficient:
 rpp = float(default=0.52)
+# S-wave average radiation pattern coefficient:
+rps = float(default=0.62)
 # Radiation pattern from focal mechanism, if available
-rps_from_focal_mechanism = boolean(default=False)
+rp_from_focal_mechanism = boolean(default=False)
 
 # Weighting type: 'noise', 'frequency' or 'no_weight'
 weighting = option('noise', 'frequency', 'no_weight', default='noise')

--- a/sourcespec/configspec.conf
+++ b/sourcespec/configspec.conf
@@ -115,11 +115,11 @@ win_length = float(default=5.0)
 
 
 # SPECTRUM PARAMETERS --------
-# Wave type to analyse: 'S', 'SH' or 'SV'
+# Wave type to analyse: 'P', 'S', 'SH' or 'SV'
 # If 'SH' or 'SV' are selected, traces are rotated in the radial-transverse
 # system. Transverse component is used for 'SH', radial (and vertical)
 # components are used for 'SV'
-wave_type = option('S', 'SH', 'SV', default='S')
+wave_type = option('P', 'S', 'SH', 'SV', default='S')
 
 # Integrate in time domain (default: integration in spectral domain)
 time_domain_int = boolean(default=False)

--- a/sourcespec/configspec.conf
+++ b/sourcespec/configspec.conf
@@ -220,6 +220,8 @@ NLL_model_dir = string(default=None)
 rho = float(default=2500)
 # S-wave average radiation pattern coefficient:
 rps = float(default=0.62)
+# P-wave average radiation pattern coefficient:
+rpp = float(default=0.52)
 # Radiation pattern from focal mechanism, if available
 rps_from_focal_mechanism = boolean(default=False)
 

--- a/sourcespec/configspec.conf
+++ b/sourcespec/configspec.conf
@@ -104,12 +104,13 @@ p_arrival_tolerance = float(default=4.0)
 s_arrival_tolerance = float(default=4.0)
 
 # Start time (in seconds) of the noise window, respect to the P arrival time
-pre_p_time = float(default=6.0)
+noise_pre_time = float(default=6.0)
 
-# Start time (in seconds) of the S-wave window, respect to the S arrival time
-pre_s_time = float(default=1.0)
+# Start time (in seconds) of the signal window, respect to the P or S arrival
+# times (see "wave_type" below)
+signal_pre_time = float(default=1.0)
 
-# Length (in seconds) for both noise and S-wave windows
+# Length (in seconds) for both noise and signal windows
 win_length = float(default=5.0)
 # -------- TIME WINDOW PARAMETERS
 

--- a/sourcespec/source_spec.py
+++ b/sourcespec/source_spec.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 # SPDX-License-Identifier: CECILL-2.1
 """
-Earthquake source parameters from inversion of S-wave spectra.
+Earthquake source parameters from inversion of P- or S-wave spectra.
 
 :copyright:
     2012 Claudio Satriano <satriano@ipgp.fr>

--- a/sourcespec/ssp_build_spectra.py
+++ b/sourcespec/ssp_build_spectra.py
@@ -205,13 +205,16 @@ def _displacement_to_moment(stats, config):
 
     From Aki&Richards,1980
     """
-    if config.wave_type[0] == 'S':
+    phase = config.wave_type[0]
+    if phase == 'S':
         v_hypo = config.hypo.vs
-    elif config.wave_type[0] == 'P':
+    elif phase == 'P':
         v_hypo = config.hypo.vp
     v_station = get_vel(
         stats.coords.longitude, stats.coords.latitude, -stats.coords.elevation,
-        config.wave_type[0], config)
+        phase, config)
+    logger.info('V%c_hypo: %.2f km/s, V%c_station: %.2f km/s'
+                % (phase, v_hypo, phase, v_station))
     v_hypo *= 1000.
     v_station *= 1000.
     v3 = v_hypo**(5./2) * v_station**(1./2)

--- a/sourcespec/ssp_build_spectra.py
+++ b/sourcespec/ssp_build_spectra.py
@@ -121,7 +121,6 @@ def _compute_h(spec_st, code, wave_type='S'):
 
 def _check_data_len(config, trace):
     traceId = trace.get_id()
-
     trace_cut = trace.copy()
     if config.wave_type[0] == 'S':
         t1 = trace.stats.arrivals['S1'][1]
@@ -137,7 +136,7 @@ def _check_data_len(config, trace):
         raise RuntimeError(msg)
     nzeros = len(np.where(trace_cut.data == 0)[0])
     if nzeros > npts/4:
-        msg = '{}: S-wave window is zero for more than 25%: skipping trace'
+        msg = '{}: Signal window is zero for more than 25%: skipping trace'
         msg = msg.format(traceId)
         raise RuntimeError(msg)
 
@@ -416,7 +415,7 @@ def build_spectra(config, st):
     """
     Build spectra and the spec_st object.
 
-    Computes S-wave (displacement) spectra from
+    Computes P- or S-wave (displacement) spectra from
     accelerometers and velocimeters, uncorrected for attenuation,
     corrected for instrumental constants, normalized by
     hypocentral distance.

--- a/sourcespec/ssp_build_spectra.py
+++ b/sourcespec/ssp_build_spectra.py
@@ -198,6 +198,10 @@ def _check_noise_level(trace_signal, trace_noise):
         raise RuntimeError(msg)
 
 
+# store log messages to avoid duplicates
+velocity_log_messages = []
+
+
 def _displacement_to_moment(stats, config):
     """
     Return the coefficient for converting displacement to seismic moment.
@@ -212,8 +216,14 @@ def _displacement_to_moment(stats, config):
     v_station = get_vel(
         stats.coords.longitude, stats.coords.latitude, -stats.coords.elevation,
         phase, config)
-    logger.info('V%c_hypo: %.2f km/s, V%c_station: %.2f km/s'
-                % (phase, v_hypo, phase, v_station))
+    specid = '.'.join((
+        stats.network, stats.station, stats.location, stats.channel))
+    msg = '{}: V{}_hypo: {:.2f} km/s, V{}_station: {:.2f} km/s'.format(
+            specid, phase.lower(), v_hypo, phase.lower(), v_station)
+    global velocity_log_messages
+    if msg not in velocity_log_messages:
+        logger.info(msg)
+        velocity_log_messages.append(msg)
     v_hypo *= 1000.
     v_station *= 1000.
     v3 = v_hypo**(5./2) * v_station**(1./2)

--- a/sourcespec/ssp_data_types.py
+++ b/sourcespec/ssp_data_types.py
@@ -93,7 +93,8 @@ class Bounds(object):
             return minmax
 
     def _Qo_to_t_star(self):
-        travel_time = self.spec.stats.travel_times['S']
+        phase = self.config.wave_type[0]
+        travel_time = self.spec.stats.travel_times[phase]
         t_star_bounds = travel_time/self.config.Qo_min_max
         return sorted(t_star_bounds)
 

--- a/sourcespec/ssp_inversion.py
+++ b/sourcespec/ssp_inversion.py
@@ -274,7 +274,7 @@ def _spec_inversion(config, spec, spec_weight):
 
     # additional parameters, computed from fc, Mw and t_star
     vs = config.vs_source
-    travel_time = spec.stats.travel_times['S']
+    travel_time = spec.stats.travel_times[config.wave_type[0]]
     # seismic moment
     par['Mo'] = mag_to_moment(par['Mw'])
     # source radius in meters

--- a/sourcespec/ssp_parse_arguments.py
+++ b/sourcespec/ssp_parse_arguments.py
@@ -38,11 +38,11 @@ def _get_description(progname):
     if progname == 'source_spec':
         nargs = '+'
         description = 'Estimation of seismic source parameters from '
-        description += 'inversion of S-wave spectra.'
+        description += 'inversion of P- or S-wave displacement spectra.'
         epilog = ''
     elif progname == 'source_model':
         nargs = '*'
-        description = 'Direct modeling of S-wave spectra.'
+        description = 'Direct modeling of P- or S-wave displacement spectra.'
         epilog = 'Several values of moment magnitude, seismic moment, t-star\n'
         epilog += 'and alpha can be specified using a comma-separated list,'
         epilog += 'eg.:\n'

--- a/sourcespec/ssp_plot_traces.py
+++ b/sourcespec/ssp_plot_traces.py
@@ -198,10 +198,14 @@ def _plot_trace(config, trace, ntraces, tmax,
         ax.add_patch(rect)
     except KeyError:
         pass
-    # S-wave window
-    S1 = trace.stats.arrivals['S1'][1] - trace.stats.starttime
-    S2 = trace.stats.arrivals['S2'][1] - trace.stats.starttime
-    rect = patches.Rectangle((S1, 0), width=S2-S1, height=1,
+    # Signal window
+    if config.wave_type[0] == 'S':
+        t1 = trace.stats.arrivals['S1'][1] - trace.stats.starttime
+        t2 = trace.stats.arrivals['S2'][1] - trace.stats.starttime
+    elif config.wave_type[0] == 'P':
+        t1 = trace.stats.arrivals['P1'][1] - trace.stats.starttime
+        t2 = trace.stats.arrivals['P2'][1] - trace.stats.starttime
+    rect = patches.Rectangle((t1, 0), width=t2-t1, height=1,
                              transform=trans, color='yellow',
                              alpha=0.5, zorder=-1)
     ax.add_patch(rect)

--- a/sourcespec/ssp_plot_traces.py
+++ b/sourcespec/ssp_plot_traces.py
@@ -240,7 +240,7 @@ def _add_labels(axes, plotn, ncols):
 
 def _trim_traces(config, st):
     for trace in st:
-        t1 = (trace.stats.arrivals['P'][1] - config.pre_p_time)
+        t1 = (trace.stats.arrivals['P'][1] - config.noise_pre_time)
         t2 = (trace.stats.arrivals['S'][1] + 3 * config.win_length)
         trace.trim(starttime=t1, endtime=t2, pad=True, fill_value=0)
 

--- a/sourcespec/ssp_process_traces.py
+++ b/sourcespec/ssp_process_traces.py
@@ -98,22 +98,22 @@ def _check_sn_ratio(config, trace):
     t1 = trace_noise.stats.arrivals['N1'][1]
     t2 = trace_noise.stats.arrivals['N2'][1]
     trace_noise.trim(starttime=t1, endtime=t2, pad=True, fill_value=0)
-    # S window for s/n ratio
-    trace_cutS = trace.copy()
+    # signal window for s/n ratio
+    trace_signal = trace.copy()
     # remove the mean...
-    trace_cutS.detrend(type='constant')
+    trace_signal.detrend(type='constant')
     # ...and the linear trend...
-    trace_cutS.detrend(type='linear')
+    trace_signal.detrend(type='linear')
     if config.wave_type[0] == 'S':
-        t1 = trace_cutS.stats.arrivals['S1'][1]
-        t2 = trace_cutS.stats.arrivals['S2'][1]
+        t1 = trace_signal.stats.arrivals['S1'][1]
+        t2 = trace_signal.stats.arrivals['S2'][1]
     elif config.wave_type[0] == 'P':
-        t1 = trace_cutS.stats.arrivals['P1'][1]
-        t2 = trace_cutS.stats.arrivals['P2'][1]
-    trace_cutS.trim(starttime=t1, endtime=t2, pad=True, fill_value=0)
+        t1 = trace_signal.stats.arrivals['P1'][1]
+        t2 = trace_signal.stats.arrivals['P2'][1]
+    trace_signal.trim(starttime=t1, endtime=t2, pad=True, fill_value=0)
     rmsnoise2 = np.power(trace_noise.data, 2).sum()
     rmsnoise = np.sqrt(rmsnoise2)
-    rmsS2 = np.power(trace_cutS.data, 2).sum()
+    rmsS2 = np.power(trace_signal.data, 2).sum()
     rmsS = np.sqrt(rmsS2)
     if rmsnoise == 0:
         msg = '{} {}: empty noise window: skipping trace'
@@ -186,7 +186,7 @@ def _merge_stream(config, st):
             msg += 'skipping trace'
             msg = msg.format(traceid, overlap_max)
             raise RuntimeError(msg)
-    # Then, compute the same statisics for the S-wave window.
+    # Then, compute the same statisics for the signal window.
     st_cut = st.copy()
     if config.wave_type[0] == 'S':
         t1 = st[0].stats.arrivals['S1'][1]
@@ -212,7 +212,7 @@ def _merge_stream(config, st):
         raise RuntimeError(msg)
     overlap_duration = -1 * sum(g[6] for g in overlaps)
     if overlap_duration > 0:
-        msg = '{}: S-wave window has {:.3f} seconds of overlaps.'
+        msg = '{}: Signal window has {:.3f} seconds of overlaps.'
         msg = msg.format(traceid, overlap_duration)
         logger.info(msg)
     # Finally, demean and remove gaps and overlaps.

--- a/sourcespec/ssp_process_traces.py
+++ b/sourcespec/ssp_process_traces.py
@@ -70,7 +70,7 @@ def _check_signal_level(config, trace):
 
 
 def _check_clipping(config, trace):
-    t1 = (trace.stats.arrivals['P'][1] - config.pre_p_time)
+    t1 = (trace.stats.arrivals['P'][1] - config.noise_pre_time)
     t2 = (trace.stats.arrivals['S'][1] + config.win_length)
     tr = trace.copy().trim(t1, t2).detrend('demean')
     npts = len(tr.data)
@@ -258,17 +258,17 @@ def _add_hypo_dist_and_arrivals(config, st):
             msg = msg.format(trace.id)
             raise RuntimeError(msg)
         # Signal window for spectral analysis (S phase)
-        t1 = s_arrival_time - config.pre_s_time
+        t1 = s_arrival_time - config.signal_pre_time
         t2 = t1 + config.win_length
         trace.stats.arrivals['S1'] = ('S1', t1)
         trace.stats.arrivals['S2'] = ('S2', t2)
         # Signal window for spectral analysis (P phase)
-        t1 = p_arrival_time - config.pre_s_time
+        t1 = p_arrival_time - config.signal_pre_time
         t2 = t1 + min(config.win_length, s_arrival_time-p_arrival_time)
         trace.stats.arrivals['P1'] = ('P1', t1)
         trace.stats.arrivals['P2'] = ('P2', t2)
         # Noise window for spectral analysis
-        t1 = p_arrival_time - config.pre_p_time
+        t1 = p_arrival_time - config.noise_pre_time
         t2 = t1 + config.win_length
         trace.stats.arrivals['N1'] = ('N1', t1)
         trace.stats.arrivals['N2'] = ('N2', t2)

--- a/sourcespec/ssp_process_traces.py
+++ b/sourcespec/ssp_process_traces.py
@@ -104,8 +104,12 @@ def _check_sn_ratio(config, trace):
     trace_cutS.detrend(type='constant')
     # ...and the linear trend...
     trace_cutS.detrend(type='linear')
-    t1 = trace_cutS.stats.arrivals['S1'][1]
-    t2 = trace_cutS.stats.arrivals['S2'][1]
+    if config.wave_type[0] == 'S':
+        t1 = trace_cutS.stats.arrivals['S1'][1]
+        t2 = trace_cutS.stats.arrivals['S2'][1]
+    elif config.wave_type[0] == 'P':
+        t1 = trace_cutS.stats.arrivals['P1'][1]
+        t2 = trace_cutS.stats.arrivals['P2'][1]
     trace_cutS.trim(starttime=t1, endtime=t2, pad=True, fill_value=0)
     rmsnoise2 = np.power(trace_noise.data, 2).sum()
     rmsnoise = np.sqrt(rmsnoise2)
@@ -184,11 +188,15 @@ def _merge_stream(config, st):
             raise RuntimeError(msg)
     # Then, compute the same statisics for the S-wave window.
     st_cut = st.copy()
-    t1 = st[0].stats.arrivals['S1'][1]
-    t2 = st[0].stats.arrivals['S2'][1]
+    if config.wave_type[0] == 'S':
+        t1 = st[0].stats.arrivals['S1'][1]
+        t2 = st[0].stats.arrivals['S2'][1]
+    elif config.wave_type[0] == 'P':
+        t1 = st[0].stats.arrivals['P1'][1]
+        t2 = st[0].stats.arrivals['P2'][1]
     st_cut.trim(starttime=t1, endtime=t2)
     if not st_cut:
-        msg = '{}: No signal for the selected S-wave cut interval: '
+        msg = '{}: No signal for the selected %c-wave cut interval: ' % config.wave_type[0]
         msg += 'skipping trace >\n'
         msg += '> Cut interval: {} - {}'
         msg = msg.format(traceid, t1, t2)
@@ -249,11 +257,16 @@ def _add_hypo_dist_and_arrivals(config, st):
             msg = '{}: Unable to get S arrival time: skipping trace'
             msg = msg.format(trace.id)
             raise RuntimeError(msg)
-        # Signal window for spectral analysis
+        # Signal window for spectral analysis (S phase)
         t1 = s_arrival_time - config.pre_s_time
         t2 = t1 + config.win_length
         trace.stats.arrivals['S1'] = ('S1', t1)
         trace.stats.arrivals['S2'] = ('S2', t2)
+        # Signal window for spectral analysis (P phase)
+        t1 = p_arrival_time - config.pre_s_time
+        t2 = t1 + min(config.win_length, s_arrival_time-p_arrival_time)
+        trace.stats.arrivals['P1'] = ('P1', t1)
+        trace.stats.arrivals['P2'] = ('P2', t2)
         # Noise window for spectral analysis
         t1 = p_arrival_time - config.pre_p_time
         t2 = t1 + config.win_length

--- a/sourcespec/ssp_radiation_pattern.py
+++ b/sourcespec/ssp_radiation_pattern.py
@@ -80,11 +80,14 @@ def _rad_patt_SH(phi, dip, rake, takeoff):
 
 
 # Cache radiation patterns
-rps_cache = dict()
+rp_cache = dict()
+# Cache messages to avoid duplication
+rp_msg_cache = []
 
 
 def get_radiation_pattern_coefficient(stats, config):
-    if not config.rps_from_focal_mechanism:
+    global rp_msg_cache
+    if not config.rp_from_focal_mechanism:
         if config.wave_type[0] == 'S':
             return config.rps
         elif config.wave_type[0] == 'P':
@@ -94,37 +97,50 @@ def get_radiation_pattern_coefficient(stats, config):
         dip = stats.hypo.dip
         rake = stats.hypo.rake
     except Exception:
-        logger.warning(
-            'Cannot find focal mechanism. Using "rp[p/s]" value from config file')
+        msg = 'Cannot find focal mechanism. Using "{}" value from config file'
         if config.wave_type[0] == 'S':
-            return config.rps
+            msg = msg.format('rps')
+            rp = config.rps
         elif config.wave_type[0] == 'P':
-            return config.rpp
+            msg = msg.format('rpp')
+            rp = config.rpp
+        if msg not in rp_msg_cache:
+            logger.warning(msg)
+            rp_msg_cache.append(msg)
+        return rp
     traceid = '.'.join(
         (stats.network, stats.station, stats.location, stats.channel))
     wave = config.wave_type
     key = '{}_{}'.format(traceid, wave)
-    global rps_cache
+    global rp_cache
     try:
-        rps = rps_cache[key]
-        return rps
+        rp = rp_cache[key]
+        return rp
     except KeyError:
         pass
     try:
         takeoff_angle = stats.takeoff_angles[config.wave_type[0]]
     except Exception:
-        logger.warning(
-            '{}: Cannot find takeoff angle. '
-            'Using "rps" value from config file'.format(traceid))
-        return config.rps
-    rps = radiation_pattern(
+        msg = '{}: Cannot find takeoff angle. '
+        msg += 'Using "{}" value from config file'
+        if config.wave_type[0] == 'S':
+            msg = msg.format(traceid, 'rps')
+            rp = config.rps
+        elif config.wave_type[0] == 'P':
+            msg = msg.format(traceid, 'rpp')
+            rp = config.rpp
+        if msg not in rp_msg_cache:
+            logger.warning(msg)
+            rp_msg_cache.append(msg)
+        return rp
+    rp = radiation_pattern(
         strike, dip, rake, takeoff_angle, stats.azimuth, wave)
     # we are interested only in amplitude
-    # (SV and SH radiation patterns have a sign)
-    rps = abs(rps)
+    # (P, SV and SH radiation patterns have a sign)
+    rp = abs(rp)
     logger.info(
         '{}: {} radiation pattern from focal mechanism: {:.2f}'.format(
-            traceid, wave, rps
+            traceid, wave, rp
         ))
-    rps_cache[key] = rps
-    return rps
+    rp_cache[key] = rp
+    return rp

--- a/sourcespec/ssp_radiation_pattern.py
+++ b/sourcespec/ssp_radiation_pattern.py
@@ -85,15 +85,21 @@ rps_cache = dict()
 
 def get_radiation_pattern_coefficient(stats, config):
     if not config.rps_from_focal_mechanism:
-        return config.rps
+        if config.wave_type[0] == 'S':
+            return config.rps
+        elif config.wave_type[0] == 'P':
+            return config.rpp
     try:
         strike = stats.hypo.strike
         dip = stats.hypo.dip
         rake = stats.hypo.rake
     except Exception:
         logger.warning(
-            'Cannot find focal mechanism. Using "rps" value from config file')
-        return config.rps
+            'Cannot find focal mechanism. Using "rp[p/s]" value from config file')
+        if config.wave_type[0] == 'S':
+            return config.rps
+        elif config.wave_type[0] == 'P':
+            return config.rpp
     traceid = '.'.join(
         (stats.network, stats.station, stats.location, stats.channel))
     wave = config.wave_type
@@ -105,7 +111,7 @@ def get_radiation_pattern_coefficient(stats, config):
     except KeyError:
         pass
     try:
-        takeoff_angle = stats.takeoff_angles['S']
+        takeoff_angle = stats.takeoff_angles[config.wave_type[0]]
     except Exception:
         logger.warning(
             '{}: Cannot find takeoff angle. '

--- a/sourcespec/ssp_read_traces.py
+++ b/sourcespec/ssp_read_traces.py
@@ -868,8 +868,8 @@ def _parse_hypo71_picks(config):
 
 
 def _hypo_vel(hypo, config):
-    vs = get_vel(hypo.longitude, hypo.latitude, hypo.depth, 'S', config)
-    hypo.vs = vs
+    hypo.vp = get_vel(hypo.longitude, hypo.latitude, hypo.depth, 'P', config)
+    hypo.vs = get_vel(hypo.longitude, hypo.latitude, hypo.depth, 'S', config)
 
 
 def _build_filelist(path, filelist, tmpdir):

--- a/sourcespec/ssp_setup.py
+++ b/sourcespec/ssp_setup.py
@@ -246,6 +246,8 @@ def _update_config_file(config_file, configspec):
         'PLOT_SAVE_FORMAT': 'plot_save_format',
         'vp': 'vp_source',
         'vs': 'vs_source',
+        'pre_p_time': 'noise_pre_time',
+        'pre_s_time': 'signal_pre_time',
     }
     for old_opt, new_opt in migrate_options.items():
         if old_opt in config_obj:
@@ -325,6 +327,16 @@ def _check_deprecated_config_options(config_obj):
     if 'vs' in config_obj:
         deprecation_msgs.append(
             '> "vs" config parameter has been renamed to "vs_source".\n'
+        )
+    if 'pre_p_time' in config_obj:
+        deprecation_msgs.append(
+            '> "pre_p_time" config parameter has been renamed to '
+            '"noise_pre_time".\n'
+        )
+    if 'pre_s_time' in config_obj:
+        deprecation_msgs.append(
+            '> "pre_s_time" config parameter has been renamed to '
+            '"signal_pre_time".\n'
         )
     if deprecation_msgs:
         sys.stderr.write(

--- a/sourcespec/ssp_setup.py
+++ b/sourcespec/ssp_setup.py
@@ -248,6 +248,7 @@ def _update_config_file(config_file, configspec):
         'vs': 'vs_source',
         'pre_p_time': 'noise_pre_time',
         'pre_s_time': 'signal_pre_time',
+        'rps_from_focal_mechanism': 'rp_from_focal_mechanism',
     }
     for old_opt, new_opt in migrate_options.items():
         if old_opt in config_obj:
@@ -337,6 +338,11 @@ def _check_deprecated_config_options(config_obj):
         deprecation_msgs.append(
             '> "pre_s_time" config parameter has been renamed to '
             '"signal_pre_time".\n'
+        )
+    if 'rps_from_focal_mechanism' in config_obj:
+        deprecation_msgs.append(
+            '> "rps_from_focal_mechanism" config parameter has been renamed to '
+            '"rp_from_focal_mechanism".\n'
         )
     if deprecation_msgs:
         sys.stderr.write(

--- a/sourcespec/ssp_wave_arrival.py
+++ b/sourcespec/ssp_wave_arrival.py
@@ -121,7 +121,7 @@ def _wave_arrival_taup(trace, phase):
 def _wave_arrival(trace, phase, config):
     """Get travel time and takeoff angle."""
     NLL_time_dir = config.NLL_time_dir
-    focmec = config.rps_from_focal_mechanism
+    focmec = config.rp_from_focal_mechanism
     vel = {'P': config.vp_tt, 'S': config.vs_tt}
     try:
         travel_time, takeoff_angle =\
@@ -215,7 +215,7 @@ def add_arrivals_to_trace(trace, config):
             pick_phase = phase + 'theo'
         else:
             continue
-        if config.rps_from_focal_mechanism:
+        if config.rp_from_focal_mechanism:
             logger.info(
                 '{}: {} takeoff angle: {:.1f} computed from {}'.format(
                     trace.id, phase, takeoff_angle, method


### PR DESCRIPTION
This feature branch implements inversion of P-wave spectra:
- Added 'rpp' configuration parameter for average P-wave radiation coefficient in sourcespec.conf.
- Start and end time of the P-window are computed, making sure it does not overlap with the S phase, and stored in the trace headers (in ssp_process_traces.py).
- Selection of P/S-window based on config.wave_type for computing spectra (in ssp_process_traces.py and ssp_build_spectra.py) and plotting the traces (ssp_plot_traces.py).
- Selection of Z-component only for P-wave spectra (in ssp_build_spectra.py).
- Selection of average P/S radiation coefficient or of P/S takeoff angle (when using focal mechanism) based on config.wave_type (in ssp_radiation_pattern.py).
- Selection of P/S velocities based on config.wave_type to convert displacement to moment (in ssp_build_spectra.py).
- Selection of P/S velocities based on config.wave_type to compute quality factor (in ssp_inversion.py) and to determine bounds on t_star from Qo bounds (in ssp_data_types.py).
