### PR TITLE
Option station metadata

### DIFF
--- a/sourcespec/ssp_parse_arguments.py
+++ b/sourcespec/ssp_parse_arguments.py
@@ -112,6 +112,14 @@ def _init_parser(description, epilog, nargs):
         metavar='FILE'
     )
     parser.add_argument(
+        '-m', '--station_metadata', dest='station_metadata',
+        action='store', default=None,
+        help='get station metadata from FILE (directory or single file\n'
+             'name). Supported format: StationXML, dataless SEED, SEED\n'
+             'RESP, PAZ (SAC polezero format)ml',
+        metavar='FILE'
+    )
+    parser.add_argument(
         '-n', '--evname', dest='evname',
         action='store', default=None,
         help='event name (used for plots and output files) ',

--- a/sourcespec/ssp_setup.py
+++ b/sourcespec/ssp_setup.py
@@ -496,6 +496,10 @@ def configure(options, progname, config_overrides=None):
     # Add options to config:
     config.options = options
 
+    # Add option for station_metadata
+    if options.station_metadata is not None :
+        config.station_metadata = options.station_metadata
+
     # Additional config values
     config.vertical_channel_codes = ['Z']
     config.horizontal_channel_codes_1 = ['N', 'R']


### PR DESCRIPTION
Hello again @claudiodsf 

This is adding a station_metadata option, so user could directly run a event with, e.g.,:
```bash
source_spec -t una2022spwc.raw.mseed -q una2022spwc.quakeml -m una2022spwc.stationxml
```

However, I'm not sure I made the changes where it's best suited.

Cheers

Fred