### PR TITLE
Relax noise window requirements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,33 +6,6 @@ Earthquake source parameters from P- or S-wave displacement spectra
 
 ## Unreleased
 
-### Relax noise window requirements
-Relax noise window requirements if noise weighting is not used.
-This is useful for older triggered records with noise windows
-that are short or even missing entirely. This includes the
-following changes:
-- Constrain start time of noise window to start time of trace
-- If noise RMS in time domain is zero, only raise an error if
-  noise weighting is used, otherwise just log a warning
-- If noise weighting is used and signal window is truncated to
-  the length of the noise window, a warning is logged
-- If noise weighting is not used and noise window is shorter than
-  signal window, it is zero-padded to the signal window length
-- Apply scale factor if noise window (minus zero pads) is shorter
-  than signal window when calculating spectral SNR
-- If noise RMS in spectral domain is too low, only raise an error
-  if noise weighting is used
-- Avoid zero noise spectra to be plotted
-
-### Window definitions
-Some small improvements were made in the window definitions:
-- Generate error if signal window is incomplete (P- or S-arrival
-  before the start time of the trace)
-- Generate error if noise window overlaps with P-window (instead
-  of S-window previously)
-- Constrain signal_pre_time for S-phase to half the S-P interval
-  (for short-distance records with short S-P interval)
-
 ### Input/output
 
 - New output file in YAML format. The old `.out` file is still available but
@@ -47,6 +20,21 @@ Some small improvements were made in the window definitions:
   parameter with the same name (see pull request [#16])
 - Logscale for boxplots, if parameters span a large interval
   (see pull request [#15])
+
+### Processing
+
+- Relax noise window requirements if noise weighting is not used.
+  This is useful for older triggered records with noise windows
+  that are short or even missing entirely (see pull request [#18])
+- Some small improvements were made in the window definitions
+  (see pull request [#18]):
+  - Generate error if signal window is incomplete (P- or S-arrival
+    before the start time of the trace)
+  - Generate error if noise window overlaps with P-window (instead
+    of S-window, as in previous versions)
+  - Constrain `signal_pre_time` for S-phase to half the S-P interval, if this
+    interval is shorter than `signal_pre_time` (i.e., for short-distance
+    records with short S-P interval)
 
 ### Post-Inversion
 
@@ -431,3 +419,4 @@ Initial Python port.
 [#10]: https://github.com/SeismicSource/sourcespec/issues/10
 [#15]: https://github.com/SeismicSource/sourcespec/issues/15
 [#16]: https://github.com/SeismicSource/sourcespec/issues/16
+[#18]: https://github.com/SeismicSource/sourcespec/issues/18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,33 @@ Earthquake source parameters from P- or S-wave displacement spectra
 
 ## Unreleased
 
+### Relax noise window requirements
+Relax noise window requirements if noise weighting is not used.
+This is useful for older triggered records with noise windows
+that are short or even missing entirely. This includes the
+following changes:
+- Constrain start time of noise window to start time of trace
+- If noise RMS in time domain is zero, only raise an error if
+  noise weighting is used, otherwise just log a warning
+- If noise weighting is used and signal window is truncated to
+  the length of the noise window, a warning is logged
+- If noise weighting is not used and noise window is shorter than
+  signal window, it is zero-padded to the signal window length
+- Apply scale factor if noise window (minus zero pads) is shorter
+  than signal window when calculating spectral SNR
+- If noise RMS in spectral domain is too low, only raise an error
+  if noise weighting is used
+- Avoid zero noise spectra to be plotted
+
+### Window definitions
+Some small improvements were made in the window definitions:
+- Generate error if signal window is incomplete (P- or S-arrival
+  before the start time of the trace)
+- Generate error if noise window overlaps with P-window (instead
+  of S-window previously)
+- Constrain signal_pre_time for S-phase to half the S-P interval
+  (for short-distance records with short S-P interval)
+
 ### Input/output
 
 - New output file in YAML format. The old `.out` file is still available but

--- a/sourcespec/ssp_build_spectra.py
+++ b/sourcespec/ssp_build_spectra.py
@@ -218,12 +218,10 @@ def _check_noise_level(trace_signal, trace_noise, config):
         scale_factor = 1
     trace_noise_rms = ((trace_noise.data**2 * scale_factor).sum())**0.5
     if trace_noise_rms/trace_signal_rms < 1e-6 and config.weighting == 'noise':
+        # Skip trace if noice level is too low and if noise weighting is used
         msg =\
             '{}: Noise level is too low or zero: station will be skipped'
         msg = msg.format(traceId)
-        # I think this error should only be raised if noise weighting is used
-        # Message is also confusing: it's not just ignored for noise weighting,
-        # but skipped entirely
         raise RuntimeError(msg)
 
 

--- a/sourcespec/ssp_plot_spectra.py
+++ b/sourcespec/ssp_plot_spectra.py
@@ -74,7 +74,8 @@ def _set_plot_params(config, spec_st, specnoise_st, ncols, plot_params):
         if specnoise_st:
             specnoise_sel = specnoise_st.select(
                 network=network, station=station, location=location)
-            spec_st_sel += specnoise_sel
+            if not specnoise_sel[0].data.sum() == 0:
+                spec_st_sel += specnoise_sel
         for spec in spec_st_sel:
             moment_minmax, freq_minmax =\
                 spec_minmax(spec.data, spec.get_freq(),

--- a/sourcespec/ssp_process_traces.py
+++ b/sourcespec/ssp_process_traces.py
@@ -287,7 +287,16 @@ def _add_hypo_dist_and_arrivals(config, st):
             raise RuntimeError(msg)
         # Signal window for spectral analysis (S phase)
         s_minus_p = s_arrival_time-p_arrival_time
-        t1 = s_arrival_time - min(config.signal_pre_time, s_minus_p / 2.)
+        s_pre_time = config.signal_pre_time
+        if s_minus_p/2 < s_pre_time:
+            # use (Ts-Tp)/2 if it is smaller than signal_pre_time
+            # (for short-distance records with short S-P interval)
+            s_pre_time = s_minus_p/2
+            msg = '{}: signal_pre_time is larger than (Ts-Tp)/2.'
+            msg += 'Using (Ts-Tp)/2 instead'
+            msg = msg.format(trace.id)
+            logger.warning(msg)
+        t1 = s_arrival_time - s_pre_time
         t1 = max(trace.stats.starttime, t1)
         t2 = t1 + config.win_length
         trace.stats.arrivals['S1'] = ('S1', t1)

--- a/sourcespec/ssp_process_traces.py
+++ b/sourcespec/ssp_process_traces.py
@@ -301,9 +301,6 @@ def _add_hypo_dist_and_arrivals(config, st):
         # Noise window for spectral analysis
         t1 = max(trace.stats.starttime, p_arrival_time - config.noise_pre_time)
         t2 = t1 + config.win_length
-        #if t2 >= s_arrival_time:
-        #    logger.warning(
-        #        '{}: noise window ends after S-wave arrival'.format(trace.id))
         if t2 >= p_arrival_time:
             logger.warning(
                 '{}: noise window ends after P-wave arrival'.format(trace.id))


### PR DESCRIPTION
Dear Claudio,

I would like to propose this branch for inclusion in sourcespec. It relaxes noise window requirements if noise weighting is not used. This is useful for older records or triggered records with noise windows that are short or even missing entirely.

Currently, traces with missing noise windows are skipped and for traces with noise windows shorter than win_length, the signal is (silently) truncated to the length of the noise window. In this branch:
- the start time of the noise window is constrained to the start time of the trace
- if noise RMS in time domain is zero, only raise an error if noise weighting is used, otherwise just log a warning
- if noise weighting is used and signal window is truncated to the length of the noise window, a warning is logged
- if noise weighting is not used and noise window is shorter than signal window, it is zero-padded to the length of the signal window
- apply scale factor if noise window (minus zero pads) is shorter than signal window when calculating spectral SNR
- if noise RMS in spectral domain is too low, only raise an error if noise weighting is used
- avoid zero noise spectra to be plotted

In addition, I made two further improvements in  ssp_process_traces._add_hypo_dist_and_arrivals function:
- generate error if signal window is incomplete (P- or S-arrival before the start time of the trace)
- constrain signal_pre_time for S-phase to half the S-P interval (for short-distance records with short S-P interval)

If you have any questions or remarks, let me know.
Kris