### PR TITLE
Improve clip detection

### DIFF
--- a/sourcespec/clipping_detection.py
+++ b/sourcespec/clipping_detection.py
@@ -47,13 +47,16 @@ def is_clipped(trace, sensitivity, debug=False):
     trace = trace.copy().detrend('demean')
     npts = len(trace.data)
     # Compute data histogram with a number of bins equal to 0.5% of data points
-    nbins = int(npts*0.005)
+    nbins = max(11, int(npts*0.005))
+    if nbins % 2 == 0:
+        nbins += 1
     counts, bins = np.histogram(trace.data, bins=nbins)
     counts = counts/np.max(counts)
+    bin_width = bins[1] - bins[0]
     # Compute gaussian kernel density
-    kde = gaussian_kde(trace.data, bw_method=0.2)
-    max_data = np.max(np.abs(trace.data))*1.2
-    density_points = np.linspace(-max_data, max_data, 100)
+    kde = gaussian_kde(trace.data, bw_method=0.1)
+    max_data = np.max(np.abs(trace.data))#*1.2
+    density_points = np.linspace(-max_data, max_data, 101)
     density = kde.pdf(density_points)
     maxdensity = np.max(density)
     density /= maxdensity
@@ -62,12 +65,21 @@ def is_clipped(trace, sensitivity, debug=False):
     dist_weight *= 4/dist_weight.max()
     dist_weight += 1
     density_weight = density*dist_weight
+    # Add 1 bin at start/end with value equal to min. of 5 first/last
+    # bins to ensure local maxima at start/end are recognized as peaks
+    density_weight = np.hstack([[density_weight[:5].min()],
+                                density_weight,
+                                [density_weight[-5:].min()]])
     # find peaks with minimum prominence based on clipping sensitivity
     min_prominence = [0.1, 0.05, 0.03, 0.02, 0.01]
     peaks, _ = find_peaks(
         density_weight,
         prominence=min_prominence[sensitivity-1]
     )
+    # Remove start/end bins again
+    peaks = peaks[(0 < peaks) & (peaks < 102)]
+    peaks -= 1
+    density_weight = density_weight[1:-1]
     if debug:
         import matplotlib.pyplot as plt
         fig, ax = plt.subplots(1, 2, figsize=(15, 5), sharey=True)
@@ -77,7 +89,7 @@ def is_clipped(trace, sensitivity, debug=False):
         ax[0].set_xlabel('Time (s)')
         ax[0].set_ylabel('Amplitude')
         ax[1].hist(
-            bins[:-1], bins=len(counts), weights=counts,
+            bins[:-1] + bin_width/2., bins=len(counts), weights=counts,
             orientation='horizontal')
         ax[1].plot(density, density_points, label='kernel density')
         ax[1].plot(
@@ -88,9 +100,11 @@ def is_clipped(trace, sensitivity, debug=False):
         ax[1].set_xlabel('Density')
         ax[1].legend()
         plt.show()
-    # If more than one peak, then the signal is probably clipped or distorted
-    if len(peaks) > 1:
-        return True
+    # If there is a peak in the first/last 5 bins,
+    # then the signal is probably clipped or distorted
+    for peak in peaks:
+        if peak < 5 or peak > 95:
+            return True
     else:
         return False
 

--- a/sourcespec/ssp_process_traces.py
+++ b/sourcespec/ssp_process_traces.py
@@ -81,7 +81,7 @@ def _check_clipping(config, trace):
         t2 = trace.stats.arrivals['S2'][1]
     elif config.wave_type[0] == 'P':
         t2 = trace.stats.arrivals['P2'][1]
-    #t2 = (trace.stats.arrivals['S'][1] + config.win_length)
+    t2 = (trace.stats.arrivals['S'][1] + config.win_length)
     tr = trace.copy().trim(t1, t2).detrend('demean')
     if is_clipped(tr, config.clipping_sensitivity):
         trace.stats.clipped = True

--- a/sourcespec/ssp_process_traces.py
+++ b/sourcespec/ssp_process_traces.py
@@ -81,7 +81,7 @@ def _check_clipping(config, trace):
         t2 = trace.stats.arrivals['S2'][1]
     elif config.wave_type[0] == 'P':
         t2 = trace.stats.arrivals['P2'][1]
-    t2 = (trace.stats.arrivals['S'][1] + config.win_length)
+    #t2 = (trace.stats.arrivals['S'][1] + config.win_length)
     tr = trace.copy().trim(t1, t2).detrend('demean')
     if is_clipped(tr, config.clipping_sensitivity):
         trace.stats.clipped = True


### PR DESCRIPTION
In this branch, I try to improve clip detection by checking for the presence of peaks in the first and last few bins of the amplitude histogram instead of only the presence of more than 1 peak to identify clipping.

I made the following changes:
- decreased smoothing for Gaussian kernel density
- do  not estimate kernel density beyond the max. amplitude
- add 1 bin to kernel density at start and end before peak finding, and remove it again afterwards
- only consider the presence of peaks in the first or last few (5) bins to indicate clipping
- require a minimum of 11 bins in the plotted histogram, and fixed its shift with respect to the kernel density

See also issue https://github.com/SeismicSource/sourcespec/issues/23