### PR TITLE
Use `trace.remove_response()` for instrument correction

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,7 @@ Earthquake source parameters from P- or S-wave displacement spectra
 
 ### Config file
 
+- Removed `sensitivity_only` option from `correct_instrumental_response`
 - Removed config parameter: `Mw_0_variability`
 - Removed config parameter: `clip_max_percent`
 - New config parameter: `remove_baseline`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -96,6 +96,10 @@ Earthquake source parameters from P- or S-wave displacement spectra
 - New config parameter: `n_sigma`
 - New config parameters for percentiles calculation: `lower_percentage`,
   `mid_percentage` and `upper_percentage`
+- New config parameters for filtering and spectral windowing of displacement
+  signals:
+  - `bp_freqmin_disp`, `bp_freqmax_disp`
+  - `freq1_disp`, `freq2_disp`
 
 ### Bugfixes
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@ Earthquake source parameters from P- or S-wave displacement spectra
   stations
 - Command line option `--station_metadata` for overriding the config file
   parameter with the same name (see pull request [#16])
+- Removed command line option `--no-response` for avoiding removing instrument
+  response (use the config option `correct_instrumental_response` instead)
 - Logscale for boxplots, if parameters span a large interval
   (see pull request [#15])
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,8 @@ Earthquake source parameters from P- or S-wave displacement spectra
     algorithm and the other `clipping_*` parameters to adjust the results.
   - The algorithms can also be called from the command line, e.g. for debug
     purposes, using the shell command `clipping_detection`.
+- Use modern ObsPy `trace.remove_response()` routine for instrument correction
+  (see [#27])
 - Magnitude limits for inversion are now autoset between 90% of the minimum
   of the spectral plateau and 110% of its maximum (see [#22])
 - Relax noise window requirements if noise weighting is not used.
@@ -474,3 +476,4 @@ Initial Python port.
 [#23]: https://github.com/SeismicSource/sourcespec/issues/23
 [#24]: https://github.com/SeismicSource/sourcespec/issues/24
 [#25]: https://github.com/SeismicSource/sourcespec/issues/25
+[#27]: https://github.com/SeismicSource/sourcespec/issues/27

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
         'scipy>=0.17',
         'matplotlib>=2.2',
         'pillow>=4.0.0',
-        'obspy>=1.3.0',
+        'obspy>=1.2.0',
         'pyproj',
         'tzlocal']
     )

--- a/setup.py
+++ b/setup.py
@@ -86,7 +86,7 @@ setup(
         'scipy>=0.17',
         'matplotlib>=2.2',
         'pillow>=4.0.0',
-        'obspy>=1.2.0',
+        'obspy>=1.3.0',
         'pyproj',
         'tzlocal']
     )

--- a/sourcespec/configspec.conf
+++ b/sourcespec/configspec.conf
@@ -88,11 +88,7 @@ sensitivity = string(default=None)
 database_file = string(default=None)
 
 # Correct_instrumental_response (optional, default=True):
-#   'True', 'False' or 'sensitivity only'
-# If 'sensitivity only', traces are not fully deconvolved for the instrumental
-# response: only the sensitivity is corrected (faster, especially on a large
-# number of traces).
-correct_instrumental_response = option('True', 'False', 'sensitivity_only', default='True')
+correct_instrumental_response = boolean(default=True)
 
 # Trace units.
 # Leave it to 'auto' to let the code decide, based on instrument type.

--- a/sourcespec/configspec.conf
+++ b/sourcespec/configspec.conf
@@ -64,7 +64,8 @@ max_epi_dist = float(min=0, default=None)
 #      NET.STA.LOC.CHAN
 # 3. If no traceid is specified through the PAZ file name, then it is assumed
 #    that this is a generic PAZ, valid for all the stations that do not have
-#    a specific PAZ.
+#    a specific PAZ. Use "trace_units" below to specify the units of the
+#    generic PAZ.
 # 4. SEED RESP and PAZ files do not contain station coordinates, which
 #    should therefore be in the trace header (traces in SAC format)
 station_metadata = string(default=None)

--- a/sourcespec/configspec.conf
+++ b/sourcespec/configspec.conf
@@ -44,7 +44,8 @@ use_traceids = force_list(default=None)
 # Maximum epicentral distance (km) to process a trace
 max_epi_dist = float(min=0, default=None)
 
-# Directory or single file name containing station metadata.
+# Directory or single file name containing station metadata
+# (instrument response and station coordinates).
 # Note: this parameter can be overridden by the command line option
 #       with the same name.
 # Station metadata files can be in one of the following formats:
@@ -70,11 +71,11 @@ max_epi_dist = float(min=0, default=None)
 #    should therefore be in the trace header (traces in SAC format)
 station_metadata = string(default=None)
 
-# It is also possible to provide a constant sensitivity (i.e., flat sensor
+# It is also possible to provide a constant sensitivity (i.e., flat instrument
 # response curve) as a numerical value or a combination of SAC header fields
 # (in this case, traces must be in SAC format).
 # This parameter overrides the response curve computed from station_metadata.
-# Leave it to None to compute sensor response from station_metadata.
+# Leave it to None to compute instrument response from station_metadata.
 # Examples:
 #  sensitivity = 1
 #  sensitivity = 1e3

--- a/sourcespec/configspec.conf
+++ b/sourcespec/configspec.conf
@@ -181,7 +181,8 @@ residuals_filepath = string(default=None)
 # Remove the signal baseline after instrument correction and before filtering
 remove_baseline = boolean(default=False)
 
-# Band-pass frequencies for accelerometers and velocimeters (Hz).
+# Band-pass frequencies (Hz) for accelerometers, velocimeters
+# and displacement sensors.
 # Use bp_freqmin_STATION and bp_freqmax_STATION to provide
 # filter frequencies for a specific STATION code.
 # TODO: calculate from sampling rate?
@@ -191,8 +192,11 @@ bp_freqmin_shortp = float(min=0, default=1.0)
 bp_freqmax_shortp = float(min=0, default=40.0)
 bp_freqmin_broadb = float(min=0, default=0.5)
 bp_freqmax_broadb = float(min=0, default=40.0)
+bp_freqmin_disp   = float(min=0, default=0.5)
+bp_freqmax_disp   = float(min=0, default=40.0)
 
-# Spectral windowing frequencies for accelerometers and velocimeters (Hz)
+# Spectral windowing frequencies (Hz) for accelerometers, velocimeters
+# and displacement sensors.
 # (spectra will be cut between these two frequencies)
 # Use freq1_STATION and freq2_STATION to provide
 # windowing frequencies for a specific STATION code.
@@ -202,6 +206,8 @@ freq1_shortp  = float(min=0, default=1.0)
 freq2_shortp  = float(min=0, default=30.0)
 freq1_broadb  = float(min=0, default=0.5)
 freq2_broadb  = float(min=0, default=30.0)
+freq1_disp    = float(min=0, default=0.5)
+freq2_disp    = float(min=0, default=30.0)
 # -------- SPECTRUM PARAMETERS
 
 

--- a/sourcespec/ssp_local_magnitude.py
+++ b/sourcespec/ssp_local_magnitude.py
@@ -110,8 +110,8 @@ def _process_trace(config, tr, t0, t1):
     freqmax = config.ml_bp_freqmax
     # ...remove response...
     pre_filt = (freqmin, freqmin*1.1, freqmax*0.9, freqmax)
-    remove_instr_response(
-        tr_process, config.correct_instrumental_response, pre_filt)
+    if config.correct_instrumental_response:
+        remove_instr_response(tr_process, pre_filt)
     # ...filter
     tr_process.filter(type='bandpass', freqmin=freqmin, freqmax=freqmax)
     # Convert to Wood-Anderson

--- a/sourcespec/ssp_parse_arguments.py
+++ b/sourcespec/ssp_parse_arguments.py
@@ -136,11 +136,6 @@ def _init_parser(description, epilog, nargs):
         action='store', default=None,
         help='only use this station', metavar='STATION'
     )
-    parser.add_argument(
-        '-N', '--no-response', dest='no_response',
-        action='store_true', default=False,
-        help='do not remove instrument response'
-    )
     return parser
 
 

--- a/sourcespec/ssp_process_traces.py
+++ b/sourcespec/ssp_process_traces.py
@@ -193,14 +193,13 @@ def _process_trace(config, trace):
     # check if trace is clipped
     _check_clipping(config, trace_process)
     # Remove instrument response
-    if not config.options.no_response:
-        correct = config.correct_instrumental_response
-        bp_freqmin, bp_freqmax = _get_bandpass_frequencies(config, trace)
-        pre_filt = (bp_freqmin, bp_freqmin*1.1, bp_freqmax*0.9, bp_freqmax)
-        if remove_instr_response(trace_process, correct, pre_filt) is None:
-            raise RuntimeError(
-                f'{trace.stats.info}: Unable to remove instrument response: '
-                'skipping trace')
+    correct = config.correct_instrumental_response
+    bp_freqmin, bp_freqmax = _get_bandpass_frequencies(config, trace)
+    pre_filt = (bp_freqmin, bp_freqmin*1.1, bp_freqmax*0.9, bp_freqmax)
+    if remove_instr_response(trace_process, correct, pre_filt) is None:
+        raise RuntimeError(
+            f'{trace.stats.info}: Unable to remove instrument response: '
+            'skipping trace')
     _remove_baseline(config, trace_process)
     filter_trace(config, trace_process)
     # Check if the trace has significant signal to noise ratio

--- a/sourcespec/ssp_process_traces.py
+++ b/sourcespec/ssp_process_traces.py
@@ -193,13 +193,15 @@ def _process_trace(config, trace):
     # check if trace is clipped
     _check_clipping(config, trace_process)
     # Remove instrument response
-    correct = config.correct_instrumental_response
     bp_freqmin, bp_freqmax = _get_bandpass_frequencies(config, trace)
-    pre_filt = (bp_freqmin, bp_freqmin*1.1, bp_freqmax*0.9, bp_freqmax)
-    if remove_instr_response(trace_process, correct, pre_filt) is None:
-        raise RuntimeError(
-            f'{trace.stats.info}: Unable to remove instrument response: '
-            'skipping trace')
+    if config.correct_instrumental_response:
+        try:
+            pre_filt = (bp_freqmin, bp_freqmin*1.1, bp_freqmax*0.9, bp_freqmax)
+            remove_instr_response(trace_process, pre_filt)
+        except Exception as e:
+            raise RuntimeError(
+                f'{trace.stats.info}: Unable to remove instrument response: '
+                'skipping trace') from e
     _remove_baseline(config, trace_process)
     filter_trace(config, trace_process)
     # Check if the trace has significant signal to noise ratio

--- a/sourcespec/ssp_read_event_metadata.py
+++ b/sourcespec/ssp_read_event_metadata.py
@@ -1,0 +1,380 @@
+
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: CECILL-2.1
+"""
+Read event metadata in QuakeML, HYPO71 or HYPOINVERSE format.
+
+:copyright:
+    2012-2023 Claudio Satriano <satriano@ipgp.fr>
+:license:
+    CeCILL Free Software License Agreement v2.1
+    (http://www.cecill.info/licences.en.html)
+"""
+import os
+import logging
+from datetime import datetime
+from obspy import UTCDateTime
+from obspy import read_events
+from sourcespec.ssp_setup import ssp_exit
+logger = logging.getLogger(__name__.split('.')[-1])
+
+
+class Hypo():
+    """A hypocenter object."""
+    latitude = None
+    longitude = None
+    depth = None
+    origin_time = None
+    evid = None
+
+
+class Pick():
+    """A pick object."""
+    station = None
+    flag = None
+    phase = None
+    polarity = None
+    quality = None
+    time = None
+
+
+def parse_qml(qml_file, evid=None):
+    if qml_file is None:
+        return None, None
+    hypo = Hypo()
+    try:
+        cat = read_events(qml_file)
+    except Exception as err:
+        logger.error(err)
+        ssp_exit(1)
+    if evid is not None:
+        ev = [e for e in cat if evid in str(e.resource_id)][0]
+    else:
+        # just take the first event
+        ev = cat[0]
+    # See if there is a preferred origin...
+    origin = ev.preferred_origin()
+    # ...or just use the first one
+    if origin is None:
+        origin = ev.origins[0]
+    hypo.origin_time = origin.time
+    hypo.latitude = origin.latitude
+    hypo.longitude = origin.longitude
+    hypo.depth = origin.depth/1000.
+    hypo.evid = ev.resource_id.id.split('/')[-1].split('=')[-1]
+
+    # See if there is a focal mechanism with nodal planes
+    try:
+        fm = ev.focal_mechanisms[0]
+        nodal_plane = fm.nodal_planes.nodal_plane_1
+        hypo.strike = nodal_plane.strike
+        hypo.dip = nodal_plane.dip
+        hypo.rake = nodal_plane.rake
+        logger.info('Found focal mechanism in QuakeML file')
+    except Exception:
+        pass
+
+    picks = []
+    for pck in ev.picks:
+        pick = Pick()
+        pick.station = pck.waveform_id.station_code
+        pick.network = pck.waveform_id.network_code
+        pick.channel = pck.waveform_id.channel_code
+        if pck.waveform_id.location_code is not None:
+            pick.location = pck.waveform_id.location_code
+        else:
+            pick.location = ''
+        if pck.onset == 'emergent':
+            pick.flag = 'E'
+        elif pck.onset == 'impulsive':
+            pick.flag = 'I'
+        try:
+            pick.phase = pck.phase_hint[0:1]
+        except Exception:
+            # ignore picks with no phase hint
+            continue
+        if pck.polarity == 'positive':
+            pick.polarity = 'U'
+        elif pck.polarity == 'negative':
+            pick.polarity = 'D'
+        pick.time = pck.time
+        picks.append(pick)
+
+    return hypo, picks
+
+
+def _parse_hypo71_hypocenter(hypo_file):
+    with open(hypo_file) as fp:
+        line = fp.readline()
+        # Skip the first line if it contains
+        # characters in the first 10 digits:
+        if any(c.isalpha() for c in line[0:10]):
+            line = fp.readline()
+    hypo = Hypo()
+    timestr = line[0:17]
+    # There are two possible formats for the timestring.
+    # We try both of them
+    try:
+        dt = datetime.strptime(timestr, '%y%m%d %H %M%S.%f')
+    except Exception:
+        dt = datetime.strptime(timestr, '%y%m%d %H%M %S.%f')
+    hypo.origin_time = UTCDateTime(dt)
+    lat = float(line[17:20])
+    lat_deg = float(line[21:26])
+    hypo.latitude = lat + lat_deg/60
+    lon = float(line[26:30])
+    lon_deg = float(line[31:36])
+    hypo.longitude = lon + lon_deg/60
+    hypo.depth = float(line[36:42])
+    evid = os.path.basename(hypo_file)
+    evid = evid.replace('.phs', '').replace('.h', '').replace('.hyp', '')
+    hypo.evid = evid
+    return hypo
+
+
+def _parse_hypo2000_hypo_line(line):
+    word = line.split()
+    hypo = Hypo()
+    timestr = ' '.join(word[0:3])
+    hypo.origin_time = UTCDateTime(timestr)
+    n = 3
+    if word[n].isnumeric():
+        # Check if word is integer
+        # In this case the format should be: degrees and minutes
+        latitude = float(word[n]) + float(word[n+1])/60.
+        n += 2
+    elif 'N' in word[n] or 'S' in word[n]:
+        # Check if there is N or S in the string
+        # In this case the format should be: degrees and minutes
+        _word = word[n].replace('N', ' ').replace('S', ' ').split()
+        latitude = float(_word[0]) + float(_word[1])/60.
+        n += 1
+    else:
+        # Otherwise latitude should be in float format
+        try:
+            latitude = float(word[n])
+        except Exception:
+            msg = 'cannot read latitude: {}'.format(word[n])
+            raise Exception(msg)
+        n += 1
+    hypo.latitude = latitude
+    if word[n].isnumeric():
+        # Check if word is integer
+        # In this case the format should be: degrees and minutes
+        longitude = float(word[n]) + float(word[n+1])/60.
+        n += 2
+    elif 'E' in word[n] or 'W' in word[n]:
+        # Check if there is E or W in the string
+        # In this case the format should be: degrees and minutes
+        _word = word[n].replace('E', ' ').replace('W', ' ').split()
+        longitude = float(_word[0]) + float(_word[1])/60.
+        n += 1
+    else:
+        # Otherwise longitude should be in float format
+        try:
+            longitude = float(word[n])
+        except Exception:
+            msg = 'cannot read longitude: {}'.format(word[n])
+            raise Exception(msg)
+        n += 1
+    hypo.longitude = longitude
+    # depth is in km, according to the hypo2000 manual
+    hypo.depth = float(word[n])
+    return hypo
+
+
+def _parse_hypo2000_station_line(line, oldpick, origin_time):
+    if oldpick is not None:
+        oldstation = oldpick.station
+        oldnetwork = oldpick.network
+        oldchannel = oldpick.channel
+    else:
+        oldstation = ""
+        oldnetwork = ""
+        oldchannel = ""
+    pick = Pick()
+    station = line[1:5].strip()
+    pick.station = station if station else oldstation
+    oldstation = pick.station
+    network = line[6:8].strip()
+    pick.network = network if network else oldnetwork
+    oldnetwork = pick.network
+    channel = line[9:12].strip()
+    pick.channel = channel if channel else oldchannel
+    oldchannel = pick.channel
+    # pick.flag = line[4:5]
+    pick.phase = line[31:34].strip()
+    if not pick.phase:
+        raise ValueError('Cannot read pick phase')
+    seconds = float(line[37:43])
+    time = origin_time.replace(second=0, microsecond=0)
+    pick.time = time + seconds
+    return pick
+
+
+def _parse_hypo2000_file(hypo_file):
+    hypo = Hypo()
+    picks = list()
+    hypo_line = False
+    station_line = False
+    oldpick = None
+    for n, line in enumerate(open(hypo_file)):
+        word = line.split()
+        if not word:
+            continue
+        if hypo_line:
+            hypo = _parse_hypo2000_hypo_line(line)
+            evid = os.path.basename(hypo_file)
+            evid = evid.replace('.txt', '')
+            hypo.evid = evid
+        if station_line:
+            try:
+                pick = _parse_hypo2000_station_line(
+                    line, oldpick, hypo.origin_time)
+                oldpick = pick
+                picks.append(pick)
+            except Exception as err:
+                logger.warning(f'Error parsing line {n} in {hypo_file}: {err}')
+                continue
+        if word[0] == 'YEAR':
+            hypo_line = True
+            continue
+        hypo_line = False
+        if word[0] == 'STA':
+            station_line = True
+    if not hypo:
+        raise TypeError('Could not find hypocenter data.')
+    return hypo, picks
+
+
+def parse_hypo_file(hypo_file):
+    picks = None
+    err_msgs = []
+    try:
+        hypo = _parse_hypo71_hypocenter(hypo_file)
+        return hypo, picks
+    except Exception as err:
+        msg = '{}: Not a hypo71 hypocenter file'.format(hypo_file)
+        err_msgs.append(msg)
+        msg = 'Parsing error: ' + str(err)
+        err_msgs.append(msg)
+    try:
+        hypo, picks = _parse_hypo2000_file(hypo_file)
+        return hypo, picks
+    except Exception as err:
+        msg = '{}: Not a hypo2000 hypocenter file'.format(hypo_file)
+        err_msgs.append(msg)
+        msg = 'Parsing error: ' + str(err)
+        err_msgs.append(msg)
+    # If we arrive here, the file was not recognized as valid
+    for msg in err_msgs:
+        logger.error(msg)
+    ssp_exit(1)
+
+
+def _is_hypo71_picks(pick_file):
+    for line in open(pick_file):
+        # remove newline
+        line = line.replace('\n', '')
+        # skip separator and empty lines
+        stripped_line = line.strip()
+        if stripped_line == '10' or stripped_line == '':
+            continue
+        # Check if it is a pick line
+        # 6th character should be alpha (phase name: P or S)
+        # other character should be digits (date/time)
+        if not (line[5].isalpha() and
+                line[9].isdigit() and
+                line[20].isdigit()):
+            msg = '{}: Not a hypo71 phase file'.format(pick_file)
+            raise Exception(msg)
+
+
+def _correct_station_name(station, traceid_file):
+    if traceid_file is None:
+        return station
+    correct_traceids = _get_correct_traceids(traceid_file)
+    # get all the keys containing station name in it
+    keys = [key for key in correct_traceids
+            if station == key.split('.')[1]]
+    # then take just the first one
+    try:
+        key = keys[0]
+    except IndexError:
+        return station
+    traceid = correct_traceids[key]
+    correct_station = traceid.split('.')[1]
+    return correct_station
+
+
+def parse_hypo71_picks(config):
+    pick_file = config.options.pick_file
+    if pick_file is None:
+        return None
+
+    try:
+        _is_hypo71_picks(pick_file)
+    except Exception as err:
+        logger.error(err)
+        ssp_exit(1)
+    picks = []
+    for line in open(pick_file):
+        # remove newline
+        line = line.replace('\n', '')
+        # skip separator and empty lines
+        stripped_line = line.strip()
+        if stripped_line == '10' or stripped_line == '':
+            continue
+        # Check if it is a pick line
+        # 6th character should be alpha (phase name: P or S)
+        # other character should be digits (date/time)
+        if not (line[5].isalpha() and
+                line[9].isdigit() and
+                line[20].isdigit()):
+            continue
+
+        pick = Pick()
+        pick.station = line[0:4].strip()
+        pick.station = \
+            _correct_station_name(pick.station, config.traceid_mapping_file)
+        pick.flag = line[4:5]
+        pick.phase = line[5:6]
+        pick.polarity = line[6:7]
+        try:
+            pick.quality = int(line[7:8])
+        except ValueError:
+            # If we cannot read pick quality,
+            # we give the pick the lowest quality
+            pick.quality = 4
+        timestr = line[9:24]
+        dt = datetime.strptime(timestr, '%y%m%d%H%M%S.%f')
+        pick.time = UTCDateTime(dt)
+        picks.append(pick)
+
+        try:
+            stime = line[31:36]
+        except Exception:
+            continue
+        if stime.strip() == '':
+            continue
+
+        pick2 = Pick()
+        pick2.station = pick.station
+        pick2.flag = line[36:37]
+        pick2.phase = line[37:38]
+        pick2.polarity = line[38:39]
+        try:
+            pick2.quality = int(line[39:40])
+        except ValueError:
+            # If we cannot read pick quality,
+            # we give the pick the lowest quality
+            pick2.quality = 4
+        # pick2.time has the same date, hour and minutes
+        # than pick.time
+        # We therefore make a copy of pick.time,
+        # and set seconds and microseconds to 0
+        pick2.time = pick.time.replace(second=0, microsecond=0)
+        # finally we add stime
+        pick2.time += float(stime)
+        picks.append(pick2)
+    return picks

--- a/sourcespec/ssp_read_station_metadata.py
+++ b/sourcespec/ssp_read_station_metadata.py
@@ -121,7 +121,7 @@ class PAZ():
         Convert PAZ object to an Inventory object.
         """
         resp = Response().from_paz(
-            self.zeros, self.poles, stage_gain=1,
+            self.zeros, self.poles, stage_gain=self.sensitivity,
             input_units=self.input_units, output_units='COUNTS')
         resp.instrument_sensitivity.value = self.sensitivity
         channel = Channel(

--- a/sourcespec/ssp_read_station_metadata.py
+++ b/sourcespec/ssp_read_station_metadata.py
@@ -41,6 +41,15 @@ class PAZ():
         if file is not None:
             self._read(file)
 
+    def __str__(self):
+        return (
+            f'PAZ: {self.seedID}'
+            f'  zeros: {self.zeros}'
+            f'  poles: {self.poles}'
+            f'  sensitivity: {self.sensitivity}'
+            f'  input_units: {self.input_units}'
+        )
+
     @property
     def seedID(self):
         return self._seedID
@@ -68,7 +77,7 @@ class PAZ():
         self.input_units = None
         if instr_code in instr_codes_vel:
             band_code = self.channel[0]
-            # SEED standard band codes from higher to lower sampling rate
+            # SEED standard band codes for velocity channels
             # https://ds.iris.edu/ds/nodes/dmc/data/formats/seed-channel-naming
             if band_code in ['B', 'C', 'D', 'E', 'F', 'G', 'H', 'S']:
                 self.input_units = 'M/S'

--- a/sourcespec/ssp_read_station_metadata.py
+++ b/sourcespec/ssp_read_station_metadata.py
@@ -116,17 +116,20 @@ def _read_paz_file(file):
     try:
         # check if trace_id is an actual trace ID
         net, sta, loc, chan = trace_id.split('.')
-        input_units = _find_input_units(trace_id)
     except ValueError:
         # otherwhise, let's use this PAZ for a generic trace ID
         net = 'XX'
         sta = 'GENERIC'
         loc = 'XX'
         chan = 'XXX'
-        # We use M/S as default input units, if "trace_units" is specified
-        # in the config file, we will change this later
-        input_units = 'M/S'
         logger.info(f'Using generic trace ID for PAZ file {file}')
+    try:
+        input_units = _find_input_units(trace_id)
+    except ValueError:
+        input_units = 'M/S'
+        logger.info(
+            f'Cannot find input units for trace ID "{trace_id}", '
+            'using M/S as default.')
     paz = PAZFile(file)
     resp = Response().from_paz(
         paz.zeros, paz.poles, stage_gain=1,

--- a/sourcespec/ssp_read_station_metadata.py
+++ b/sourcespec/ssp_read_station_metadata.py
@@ -1,0 +1,130 @@
+# -*- coding: utf-8 -*-
+# SPDX-License-Identifier: CECILL-2.1
+"""
+Read station metadata in StationXML, dataless SEED, SEED RESP,
+PAZ (SAC polezero format).
+
+:copyright:
+    2012-2023 Claudio Satriano <satriano@ipgp.fr>
+:license:
+    CeCILL Free Software License Agreement v2.1
+    (http://www.cecill.info/licences.en.html)
+"""
+import os
+import re
+import logging
+from obspy import read_inventory
+from obspy.core.inventory import Inventory, Network, Station, Channel, Response
+logger = logging.getLogger(__name__.split('.')[-1])
+
+
+def _parse_paz_file(file):
+    lines = iter(open(file, 'r'))
+    zeros = []
+    poles = []
+    constant = None
+    linenumber = 0
+    try:
+        for line in lines:
+            linenumber += 1
+            word = line.split()
+            if not word:
+                continue
+            if word[0] == 'ZEROS':
+                nzeros = int(word[1])
+                for _ in range(nzeros):
+                    linenumber += 1
+                    _zero = complex(*map(float, next(lines).split()))
+                    zeros.append(_zero)
+            if word[0] == 'POLES':
+                npoles = int(word[1])
+                for _ in range(npoles):
+                    linenumber += 1
+                    _pole = complex(*map(float, next(lines).split()))
+                    poles.append(_pole)
+            if word[0] == 'CONSTANT':
+                constant = float(word[1])
+    except Exception:
+        msg = 'Unable to parse file "{}" as PAZ. '.format(file)
+        msg += 'Parse error at line {}'.format(linenumber)
+        raise TypeError(msg)
+    if constant is None:
+        msg = 'Unable to parse file "{}" as PAZ. '.format(file)
+        msg += 'Cannot find a "CONSTANT" value'
+        raise TypeError(msg)
+    return zeros, poles, constant
+
+
+def _read_paz_file(file):
+    """
+    Read a paz file into an ``Inventory``object.
+
+    - paz file must have ".pz" or ".paz" suffix (or no suffix)
+    - paz file name (without prefix and suffix) can have
+      the trace_id (NET.STA.LOC.CHAN) of the corresponding trace in the last
+      part of his name (e.g., 20110208_1600.NOW.IV.CRAC.00.EHZ.paz),
+      otherwhise it will be treaten as a generic paz.
+    """
+    bname = os.path.basename(file)
+    # strip .pz suffix, if there
+    bname = re.sub('.pz$', '', bname)
+    # strip .paz suffix, if there
+    bname = re.sub('.paz$', '', bname)
+    # we assume that the last four fields of bname
+    # (separated by '.') are the trace_id
+    trace_id = '.'.join(bname.split('.')[-4:])
+    try:
+        # check if trace_id is an actual trace ID
+        net, sta, loc, chan = trace_id.split('.')
+    except ValueError:
+        # otherwhise, let's use this PAZ for a generic trace ID
+        net = 'XX'
+        sta = 'GENERIC'
+        loc = 'XX'
+        chan = 'XXX'
+    zeros, poles, constant = _parse_paz_file(file)
+    resp = Response().from_paz(
+        zeros, poles, stage_gain=1, input_units='M/S', output_units='COUNTS')
+    resp.instrument_sensitivity.value = constant
+    channel = Channel(
+        code=chan, location_code=loc, response=resp,
+        latitude=0, longitude=0, elevation=123456, depth=123456)
+    station = Station(
+        code=sta, channels=[channel, ],
+        latitude=0, longitude=0, elevation=123456)
+    network = Network(code=net, stations=[station, ])
+    inv = Inventory(networks=[network, ])
+    return inv
+
+
+def read_station_metadata(path):
+    """
+    Read station metadata into an ObsPy ``Inventory`` object.
+    """
+    if path is None:
+        return None
+    logger.info('Reading station metadata...')
+    inventory = Inventory()
+    if os.path.isdir(path):
+        filelist = [os.path.join(path, file) for file in os.listdir(path)]
+    else:
+        filelist = [path, ]
+    for file in sorted(filelist):
+        if os.path.isdir(file):
+            # we do not enter into subdirs of "path"
+            continue
+        logger.info('Reading station metadata from file: {}'.format(file))
+        try:
+            inventory += read_inventory(file)
+        except Exception:
+            msg1 = 'Unable to parse file "{}" as Inventory'.format(file)
+            try:
+                inventory += _read_paz_file(file)
+            except Exception as msg2:
+                logger.warning(msg1)
+                logger.warning(msg2)
+                continue
+    if not inventory:
+        inventory = None
+    logger.info('Reading station metadata: done')
+    return inventory

--- a/sourcespec/ssp_read_station_metadata.py
+++ b/sourcespec/ssp_read_station_metadata.py
@@ -193,10 +193,10 @@ def read_station_metadata(path):
     :return: inventory
     :rtype: :class:`~obspy.core.inventory.inventory.Inventory`
     """
-    if path is None:
-        return None
-    logger.info('Reading station metadata...')
     inventory = Inventory()
+    if path is None:
+        return inventory
+    logger.info('Reading station metadata...')
     if os.path.isdir(path):
         filelist = [os.path.join(path, file) for file in os.listdir(path)]
     else:
@@ -216,7 +216,5 @@ def read_station_metadata(path):
                 logger.warning(msg1)
                 logger.warning(msg2)
                 continue
-    if not inventory:
-        inventory = None
     logger.info('Reading station metadata: done')
     return inventory

--- a/sourcespec/ssp_read_traces.py
+++ b/sourcespec/ssp_read_traces.py
@@ -92,7 +92,14 @@ def _add_instrtype(trace):
             instr_code = codes['instr_code']
         except AttributeError as e:
             raise RuntimeError(
-                f'{trace.id}: cannot find instrtype for trace: skipping trace'
+                f'{trace.id}: cannot find instrtype for trace: '
+                'missing SAC header field "kinst": skipping trace'
+            ) from e
+        except KeyError as e:
+            raise RuntimeError(
+                f'{trace.id}: cannot find instrtype for trace: '
+                f'unknown instrument "{trace.stats.sac.kinst}": '
+                'skipping trace'
             ) from e
         orientation = trace.stats.channel[-1]
         trace.stats.channel = ''.join((band_code, instr_code, orientation))

--- a/sourcespec/ssp_read_traces.py
+++ b/sourcespec/ssp_read_traces.py
@@ -25,29 +25,17 @@ import shutil
 import tarfile
 import tempfile
 import json
-from datetime import datetime
 from obspy import read
-from obspy.core import Stream, UTCDateTime
+from obspy.core import Stream
 from obspy.core.util import AttribDict
 from obspy.io.sac import attach_paz
 from obspy.core.inventory import Inventory
-from obspy import read_events
 from sourcespec.ssp_setup import ssp_exit, instr_codes_vel, instr_codes_acc
 from sourcespec.ssp_util import get_vel
 from sourcespec.ssp_read_station_metadata import read_station_metadata
+from sourcespec.ssp_read_event_metadata import (
+    parse_qml, parse_hypo_file, parse_hypo71_picks, Pick)
 logger = logging.getLogger(__name__.split('.')[-1])
-
-
-class Pick(AttribDict):
-    """A pick object."""
-
-    def __init__(self):
-        self.station = None
-        self.flag = None
-        self.phase = None
-        self.polarity = None
-        self.quality = None
-        self.time = None
 
 
 # TRACE MANIPULATION ----------------------------------------------------------
@@ -81,23 +69,6 @@ def _correct_traceid(trace, traceid_file):
         trace.stats.channel = chan
     except KeyError:
         pass
-
-
-def _correct_station_name(station, traceid_file):
-    if traceid_file is None:
-        return station
-    correct_traceids = _get_correct_traceids(traceid_file)
-    # get all the keys containing station name in it
-    keys = [key for key in correct_traceids
-            if station == key.split('.')[1]]
-    # then take just the first one
-    try:
-        key = keys[0]
-    except IndexError:
-        return station
-    traceid = correct_traceids[key]
-    correct_station = traceid.split('.')[1]
-    return correct_station
 
 
 def _compute_sensitivity(trace, config):
@@ -424,339 +395,6 @@ def _complete_picks(st):
 
 
 # FILE PARSING ----------------------------------------------------------------
-def _parse_qml(qml_file, evid=None):
-    if qml_file is None:
-        return None, None
-
-    hypo = AttribDict()
-    hypo.latitude = None
-    hypo.longitude = None
-    hypo.depth = None
-    hypo.origin_time = None
-    hypo.evid = None
-
-    try:
-        cat = read_events(qml_file)
-    except Exception as err:
-        logger.error(err)
-        ssp_exit(1)
-
-    if evid is not None:
-        ev = [e for e in cat if evid in str(e.resource_id)][0]
-    else:
-        # just take the first event
-        ev = cat[0]
-    # See if there is a preferred origin...
-    origin = ev.preferred_origin()
-    # ...or just use the first one
-    if origin is None:
-        origin = ev.origins[0]
-    hypo.origin_time = origin.time
-    hypo.latitude = origin.latitude
-    hypo.longitude = origin.longitude
-    hypo.depth = origin.depth/1000.
-    hypo.evid = ev.resource_id.id.split('/')[-1].split('=')[-1]
-
-    # See if there is a focal mechanism with nodal planes
-    try:
-        fm = ev.focal_mechanisms[0]
-        nodal_plane = fm.nodal_planes.nodal_plane_1
-        hypo.strike = nodal_plane.strike
-        hypo.dip = nodal_plane.dip
-        hypo.rake = nodal_plane.rake
-        logger.info('Found focal mechanism in QuakeML file')
-    except Exception:
-        pass
-
-    picks = []
-    for pck in ev.picks:
-        pick = Pick()
-        pick.station = pck.waveform_id.station_code
-        pick.network = pck.waveform_id.network_code
-        pick.channel = pck.waveform_id.channel_code
-        if pck.waveform_id.location_code is not None:
-            pick.location = pck.waveform_id.location_code
-        else:
-            pick.location = ''
-        if pck.onset == 'emergent':
-            pick.flag = 'E'
-        elif pck.onset == 'impulsive':
-            pick.flag = 'I'
-        try:
-            pick.phase = pck.phase_hint[0:1]
-        except Exception:
-            # ignore picks with no phase hint
-            continue
-        if pck.polarity == 'positive':
-            pick.polarity = 'U'
-        elif pck.polarity == 'negative':
-            pick.polarity = 'D'
-        pick.time = pck.time
-        picks.append(pick)
-
-    return hypo, picks
-
-
-def _parse_hypo71_hypocenter(hypo_file):
-    with open(hypo_file) as fp:
-        line = fp.readline()
-        # Skip the first line if it contains
-        # characters in the first 10 digits:
-        if any(c.isalpha() for c in line[0:10]):
-            line = fp.readline()
-    hypo = AttribDict()
-    timestr = line[0:17]
-    # There are two possible formats for the timestring.
-    # We try both of them
-    try:
-        dt = datetime.strptime(timestr, '%y%m%d %H %M%S.%f')
-    except Exception:
-        dt = datetime.strptime(timestr, '%y%m%d %H%M %S.%f')
-    hypo.origin_time = UTCDateTime(dt)
-    lat = float(line[17:20])
-    lat_deg = float(line[21:26])
-    hypo.latitude = lat + lat_deg/60
-    lon = float(line[26:30])
-    lon_deg = float(line[31:36])
-    hypo.longitude = lon + lon_deg/60
-    hypo.depth = float(line[36:42])
-    evid = os.path.basename(hypo_file)
-    evid = evid.replace('.phs', '').replace('.h', '').replace('.hyp', '')
-    hypo.evid = evid
-    return hypo
-
-
-def _parse_hypo2000_hypo_line(line):
-    word = line.split()
-    hypo = AttribDict()
-    timestr = ' '.join(word[0:3])
-    hypo.origin_time = UTCDateTime(timestr)
-    n = 3
-    if word[n].isnumeric():
-        # Check if word is integer
-        # In this case the format should be: degrees and minutes
-        latitude = float(word[n]) + float(word[n+1])/60.
-        n += 2
-    elif 'N' in word[n] or 'S' in word[n]:
-        # Check if there is N or S in the string
-        # In this case the format should be: degrees and minutes
-        _word = word[n].replace('N', ' ').replace('S', ' ').split()
-        latitude = float(_word[0]) + float(_word[1])/60.
-        n += 1
-    else:
-        # Otherwise latitude should be in float format
-        try:
-            latitude = float(word[n])
-        except Exception:
-            msg = 'cannot read latitude: {}'.format(word[n])
-            raise Exception(msg)
-        n += 1
-    hypo.latitude = latitude
-    if word[n].isnumeric():
-        # Check if word is integer
-        # In this case the format should be: degrees and minutes
-        longitude = float(word[n]) + float(word[n+1])/60.
-        n += 2
-    elif 'E' in word[n] or 'W' in word[n]:
-        # Check if there is E or W in the string
-        # In this case the format should be: degrees and minutes
-        _word = word[n].replace('E', ' ').replace('W', ' ').split()
-        longitude = float(_word[0]) + float(_word[1])/60.
-        n += 1
-    else:
-        # Otherwise longitude should be in float format
-        try:
-            longitude = float(word[n])
-        except Exception:
-            msg = 'cannot read longitude: {}'.format(word[n])
-            raise Exception(msg)
-        n += 1
-    hypo.longitude = longitude
-    # depth is in km, according to the hypo2000 manual
-    hypo.depth = float(word[n])
-    return hypo
-
-
-def _parse_hypo2000_station_line(line, oldpick, origin_time):
-    if oldpick is not None:
-        oldstation = oldpick.station
-        oldnetwork = oldpick.network
-        oldchannel = oldpick.channel
-    else:
-        oldstation = ""
-        oldnetwork = ""
-        oldchannel = ""
-    pick = Pick()
-    station = line[1:5].strip()
-    pick.station = station if station else oldstation
-    oldstation = pick.station
-    network = line[6:8].strip()
-    pick.network = network if network else oldnetwork
-    oldnetwork = pick.network
-    channel = line[9:12].strip()
-    pick.channel = channel if channel else oldchannel
-    oldchannel = pick.channel
-    # pick.flag = line[4:5]
-    pick.phase = line[31:34].strip()
-    if not pick.phase:
-        raise ValueError('Cannot read pick phase')
-    seconds = float(line[37:43])
-    time = origin_time.replace(second=0, microsecond=0)
-    pick.time = time + seconds
-    return pick
-
-
-def _parse_hypo2000_file(hypo_file):
-    hypo = AttribDict()
-    picks = list()
-    hypo_line = False
-    station_line = False
-    oldpick = None
-    for n, line in enumerate(open(hypo_file)):
-        word = line.split()
-        if not word:
-            continue
-        if hypo_line:
-            hypo = _parse_hypo2000_hypo_line(line)
-            evid = os.path.basename(hypo_file)
-            evid = evid.replace('.txt', '')
-            hypo.evid = evid
-        if station_line:
-            try:
-                pick = _parse_hypo2000_station_line(
-                    line, oldpick, hypo.origin_time)
-                oldpick = pick
-                picks.append(pick)
-            except Exception as err:
-                logger.warning(f'Error parsing line {n} in {hypo_file}: {err}')
-                continue
-        if word[0] == 'YEAR':
-            hypo_line = True
-            continue
-        hypo_line = False
-        if word[0] == 'STA':
-            station_line = True
-    if not hypo:
-        raise TypeError('Could not find hypocenter data.')
-    return hypo, picks
-
-
-def _parse_hypo_file(hypo_file):
-    picks = None
-    err_msgs = []
-    try:
-        hypo = _parse_hypo71_hypocenter(hypo_file)
-        return hypo, picks
-    except Exception as err:
-        msg = '{}: Not a hypo71 hypocenter file'.format(hypo_file)
-        err_msgs.append(msg)
-        msg = 'Parsing error: ' + str(err)
-        err_msgs.append(msg)
-    try:
-        hypo, picks = _parse_hypo2000_file(hypo_file)
-        return hypo, picks
-    except Exception as err:
-        msg = '{}: Not a hypo2000 hypocenter file'.format(hypo_file)
-        err_msgs.append(msg)
-        msg = 'Parsing error: ' + str(err)
-        err_msgs.append(msg)
-    # If we arrive here, the file was not recognized as valid
-    for msg in err_msgs:
-        logger.error(msg)
-    ssp_exit(1)
-
-
-def _is_hypo71_picks(pick_file):
-    for line in open(pick_file):
-        # remove newline
-        line = line.replace('\n', '')
-        # skip separator and empty lines
-        stripped_line = line.strip()
-        if stripped_line == '10' or stripped_line == '':
-            continue
-        # Check if it is a pick line
-        # 6th character should be alpha (phase name: P or S)
-        # other character should be digits (date/time)
-        if not (line[5].isalpha() and
-                line[9].isdigit() and
-                line[20].isdigit()):
-            msg = '{}: Not a hypo71 phase file'.format(pick_file)
-            raise Exception(msg)
-
-
-def _parse_hypo71_picks(config):
-    pick_file = config.options.pick_file
-    if pick_file is None:
-        return None
-
-    try:
-        _is_hypo71_picks(pick_file)
-    except Exception as err:
-        logger.error(err)
-        ssp_exit(1)
-    picks = []
-    for line in open(pick_file):
-        # remove newline
-        line = line.replace('\n', '')
-        # skip separator and empty lines
-        stripped_line = line.strip()
-        if stripped_line == '10' or stripped_line == '':
-            continue
-        # Check if it is a pick line
-        # 6th character should be alpha (phase name: P or S)
-        # other character should be digits (date/time)
-        if not (line[5].isalpha() and
-                line[9].isdigit() and
-                line[20].isdigit()):
-            continue
-
-        pick = Pick()
-        pick.station = line[0:4].strip()
-        pick.station = \
-            _correct_station_name(pick.station, config.traceid_mapping_file)
-        pick.flag = line[4:5]
-        pick.phase = line[5:6]
-        pick.polarity = line[6:7]
-        try:
-            pick.quality = int(line[7:8])
-        except ValueError:
-            # If we cannot read pick quality,
-            # we give the pick the lowest quality
-            pick.quality = 4
-        timestr = line[9:24]
-        dt = datetime.strptime(timestr, '%y%m%d%H%M%S.%f')
-        pick.time = UTCDateTime(dt)
-        picks.append(pick)
-
-        try:
-            stime = line[31:36]
-        except Exception:
-            continue
-        if stime.strip() == '':
-            continue
-
-        pick2 = Pick()
-        pick2.station = pick.station
-        pick2.flag = line[36:37]
-        pick2.phase = line[37:38]
-        pick2.polarity = line[38:39]
-        try:
-            pick2.quality = int(line[39:40])
-        except ValueError:
-            # If we cannot read pick quality,
-            # we give the pick the lowest quality
-            pick2.quality = 4
-        # pick2.time has the same date, hour and minutes
-        # than pick.time
-        # We therefore make a copy of pick.time,
-        # and set seconds and microseconds to 0
-        pick2.time = pick.time.replace(second=0, microsecond=0)
-        # finally we add stime
-        pick2.time += float(stime)
-        picks.append(pick2)
-    return picks
-
-
 def _hypo_vel(hypo, config):
     hypo.vp = get_vel(hypo.longitude, hypo.latitude, hypo.depth, 'P', config)
     hypo.vs = get_vel(hypo.longitude, hypo.latitude, hypo.depth, 'S', config)
@@ -795,13 +433,13 @@ def read_traces(config):
     hypo = picks = None
     # parse hypocenter file
     if config.options.hypo_file is not None:
-        hypo, picks = _parse_hypo_file(config.options.hypo_file)
+        hypo, picks = parse_hypo_file(config.options.hypo_file)
     # parse pick file
     if config.options.pick_file is not None:
-        picks = _parse_hypo71_picks(config)
+        picks = parse_hypo71_picks(config)
     # parse QML file
     if config.options.qml_file is not None:
-        hypo, picks = _parse_qml(config.options.qml_file, config.options.evid)
+        hypo, picks = parse_qml(config.options.qml_file, config.options.evid)
 
     # finally, read traces
     logger.info('Reading traces...')

--- a/sourcespec/ssp_read_traces.py
+++ b/sourcespec/ssp_read_traces.py
@@ -456,9 +456,11 @@ def read_traces(config):
                 logger.warning('%s: Unknown channel orientation: "%s": '
                                'skipping trace' % (trace.id, orientation))
                 continue
-            if config.options.station is not None:
-                if not trace.stats.station == config.options.station:
-                    continue
+            # only use the station specified by the command line option
+            # "--station", if any
+            if (config.options.station is not None and
+                    trace.stats.station != config.options.station):
+                continue
             _correct_traceid(trace)
             try:
                 _add_paz_and_coords(trace, inventory, config)

--- a/sourcespec/ssp_read_traces.py
+++ b/sourcespec/ssp_read_traces.py
@@ -177,6 +177,7 @@ def _check_instrtype(trace):
     new_instrtype = None
     units = inv.get_response(trace.id, trace.stats.starttime).\
         instrument_sensitivity.input_units
+    trace.stats.units = units
     if units.lower() == 'm' and trace.stats.instrtype != 'disp':
         new_instrtype = 'disp'
     if units.lower() == 'm/s' and instrtype not in ['shortp', 'broadb']:

--- a/sourcespec/ssp_read_traces.py
+++ b/sourcespec/ssp_read_traces.py
@@ -29,12 +29,12 @@ from datetime import datetime
 from obspy import read
 from obspy.core import Stream, UTCDateTime
 from obspy.core.util import AttribDict
-from obspy import read_inventory
 from obspy.io.sac import attach_paz
-from obspy.core.inventory import Inventory, Network, Station, Channel, Response
+from obspy.core.inventory import Inventory
 from obspy import read_events
 from sourcespec.ssp_setup import ssp_exit
 from sourcespec.ssp_util import get_vel
+from sourcespec.ssp_read_station_metadata import read_station_metadata
 logger = logging.getLogger(__name__.split('.')[-1])
 
 
@@ -448,118 +448,6 @@ def _complete_picks(st):
 
 
 # FILE PARSING ----------------------------------------------------------------
-def _read_metadata(path):
-    """
-    Read metadata into an ObsPy ``Inventory`` object.
-    """
-    if path is None:
-        return None
-    logger.info('Reading station metadata...')
-    inventory = Inventory()
-    if os.path.isdir(path):
-        filelist = [os.path.join(path, file) for file in os.listdir(path)]
-    else:
-        filelist = [path, ]
-    for file in sorted(filelist):
-        if os.path.isdir(file):
-            # we do not enter into subdirs of "path"
-            continue
-        logger.info('Reading station metadata from file: {}'.format(file))
-        try:
-            inventory += read_inventory(file)
-        except Exception:
-            msg1 = 'Unable to parse file "{}" as Inventory'.format(file)
-            try:
-                inventory += _read_paz_file(file)
-            except Exception as msg2:
-                logger.warning(msg1)
-                logger.warning(msg2)
-                continue
-    if not inventory:
-        inventory = None
-    logger.info('Reading station metadata: done')
-    return inventory
-
-
-def _parse_paz_file(file):
-    lines = iter(open(file, 'r'))
-    zeros = []
-    poles = []
-    constant = None
-    linenumber = 0
-    try:
-        for line in lines:
-            linenumber += 1
-            word = line.split()
-            if not word:
-                continue
-            if word[0] == 'ZEROS':
-                nzeros = int(word[1])
-                for _ in range(nzeros):
-                    linenumber += 1
-                    _zero = complex(*map(float, next(lines).split()))
-                    zeros.append(_zero)
-            if word[0] == 'POLES':
-                npoles = int(word[1])
-                for _ in range(npoles):
-                    linenumber += 1
-                    _pole = complex(*map(float, next(lines).split()))
-                    poles.append(_pole)
-            if word[0] == 'CONSTANT':
-                constant = float(word[1])
-    except Exception:
-        msg = 'Unable to parse file "{}" as PAZ. '.format(file)
-        msg += 'Parse error at line {}'.format(linenumber)
-        raise TypeError(msg)
-    if constant is None:
-        msg = 'Unable to parse file "{}" as PAZ. '.format(file)
-        msg += 'Cannot find a "CONSTANT" value'
-        raise TypeError(msg)
-    return zeros, poles, constant
-
-
-def _read_paz_file(file):
-    """
-    Read a paz file into an ``Inventory``object.
-
-    - paz file must have ".pz" or ".paz" suffix (or no suffix)
-    - paz file name (without prefix and suffix) can have
-      the trace_id (NET.STA.LOC.CHAN) of the corresponding trace in the last
-      part of his name (e.g., 20110208_1600.NOW.IV.CRAC.00.EHZ.paz),
-      otherwhise it will be treaten as a generic paz.
-    """
-    bname = os.path.basename(file)
-    # strip .pz suffix, if there
-    bname = re.sub('.pz$', '', bname)
-    # strip .paz suffix, if there
-    bname = re.sub('.paz$', '', bname)
-    # we assume that the last four fields of bname
-    # (separated by '.') are the trace_id
-    trace_id = '.'.join(bname.split('.')[-4:])
-    try:
-        # check if trace_id is an actual trace ID
-        net, sta, loc, chan = trace_id.split('.')
-    except ValueError:
-        # otherwhise, let's use this PAZ for a generic trace ID
-        net = 'XX'
-        sta = 'GENERIC'
-        loc = 'XX'
-        chan = 'XXX'
-    zeros, poles, constant = _parse_paz_file(file)
-    resp = Response().from_paz(
-        zeros, poles, stage_gain=1, input_units='M/S', output_units='COUNTS')
-    resp.instrument_sensitivity.value = constant
-    channel = Channel(
-        code=chan, location_code=loc, response=resp,
-        latitude=0, longitude=0, elevation=123456, depth=123456)
-    station = Station(
-        code=sta, channels=[channel, ],
-        latitude=0, longitude=0, elevation=123456)
-    network = Network(code=net, stations=[station, ])
-    inv = Inventory(networks=[network, ])
-    return inv
-
-
 def _parse_qml(qml_file, evid=None):
     if qml_file is None:
         return None, None
@@ -925,8 +813,8 @@ def _build_filelist(path, filelist, tmpdir):
 # Public interface:
 def read_traces(config):
     """Read traces, store waveforms and metadata."""
-    # read metadata into an ObsPy ``Inventory`` object
-    inventory = _read_metadata(config.station_metadata)
+    # read station metadata into an ObsPy ``Inventory`` object
+    inventory = read_station_metadata(config.station_metadata)
 
     hypo = picks = None
     # parse hypocenter file

--- a/sourcespec/ssp_read_traces.py
+++ b/sourcespec/ssp_read_traces.py
@@ -172,6 +172,9 @@ def _add_paz(trace):
                 msg = str(w.message)
                 logger.warning(f'{traceid}: {msg} Time: {time}')
         attach_paz(trace, io.StringIO(sacpz))
+        sens = trace.stats.paz.sensitivity
+        trace.stats.paz.sensitivity = trace.stats.paz.gain
+        trace.stats.paz.gain = sens
     except Exception as msg:
         logger.warning(f'{traceid}: {msg} Time: {time}')
 

--- a/sourcespec/ssp_setup.py
+++ b/sourcespec/ssp_setup.py
@@ -22,6 +22,7 @@ import shutil
 import logging
 import signal
 import uuid
+import json
 import contextlib
 from datetime import datetime
 from collections import defaultdict
@@ -46,6 +47,7 @@ OS = os.name
 oldlogfile = None
 logger = None
 ssp_exit_called = False
+traceid_map = None
 OBSPY_VERSION = None
 OBSPY_VERSION_STR = None
 NUMPY_VERSION_STR = None
@@ -460,6 +462,25 @@ def _init_instrument_codes(config):
         instr_codes_acc.append(instr_code_acc_user)
 
 
+def _init_traceid_map(traceid_map_file):
+    """
+    Initialize trace ID map from file.
+    """
+    global traceid_map
+    if traceid_map_file is None:
+        return
+    try:
+        with open(traceid_map_file, 'r') as fp:
+            traceid_map = json.loads(fp.read())
+    except Exception:
+        msg = (
+            f'traceid mapping file "{traceid_map_file}" not found '
+            'or not in json format'
+        )
+        sys.stderr.write(msg + '\n')
+        ssp_exit(1)
+
+
 def configure(options, progname, config_overrides=None):
     """
     Parse command line arguments and read config file.
@@ -582,6 +603,7 @@ def configure(options, progname, config_overrides=None):
             sys.exit(1)
 
     _init_instrument_codes(config)
+    _init_traceid_map(config.traceid_mapping_file)
     _init_plotting(config.plot_show)
     # Create a dict to store figure paths
     config.figures = defaultdict(list)

--- a/sourcespec/ssp_setup.py
+++ b/sourcespec/ssp_setup.py
@@ -71,13 +71,11 @@ def _check_obspy_version():
     # special case for "rc" versions:
     OBSPY_VERSION[2] = OBSPY_VERSION[2].split('rc')[0]
     OBSPY_VERSION = tuple(map(int, OBSPY_VERSION))
-    try:
+    with contextlib.suppress(IndexError):
         # add half version number for development versions
         # check if there is a fourth field in version string:
         OBSPY_VERSION_STR.split('.')[3]
         OBSPY_VERSION = OBSPY_VERSION[:2] + (OBSPY_VERSION[2] + 0.5,)
-    except IndexError:
-        pass
     if OBSPY_VERSION < MIN_OBSPY_VERSION:
         msg = 'ERROR: ObsPy >= %s.%s.%s is required.' % MIN_OBSPY_VERSION
         msg += ' You have version: %s\n' % OBSPY_VERSION_STR
@@ -95,7 +93,7 @@ def _check_cartopy_version():
         cartopy_ver = tuple(map(int, cartopy.__version__.split('.')[:3]))
         if cartopy_ver < cartopy_min_ver:
             raise ImportError
-    except ImportError:
+    except ImportError as e:
         msg = (
             '\nPlease install cartopy >= {}.{}.{} to plot maps.\n'
             'How to install: '
@@ -105,10 +103,8 @@ def _check_cartopy_version():
             .format(*cartopy_min_ver)
         )
         if cartopy_ver is not None:
-            msg += (
-                'Installed cartopy version: {}.\n'.format(CARTOPY_VERSION_STR)
-            )
-        raise ImportError(msg)
+            msg += f'Installed cartopy version: {CARTOPY_VERSION_STR}.\n'
+        raise ImportError(msg) from e
 
 
 def _check_pyproj_version():

--- a/sourcespec/ssp_setup.py
+++ b/sourcespec/ssp_setup.py
@@ -65,7 +65,7 @@ def _check_obspy_version():
     global OBSPY_VERSION, OBSPY_VERSION_STR
     # check ObsPy version
     import obspy
-    MIN_OBSPY_VERSION = (1, 3, 0)
+    MIN_OBSPY_VERSION = (1, 2, 0)
     OBSPY_VERSION_STR = obspy.__version__
     OBSPY_VERSION = OBSPY_VERSION_STR.split('.')[:3]
     # special case for "rc" versions:

--- a/sourcespec/ssp_setup.py
+++ b/sourcespec/ssp_setup.py
@@ -65,7 +65,7 @@ def _check_obspy_version():
     global OBSPY_VERSION, OBSPY_VERSION_STR
     # check ObsPy version
     import obspy
-    MIN_OBSPY_VERSION = (1, 2, 0)
+    MIN_OBSPY_VERSION = (1, 3, 0)
     OBSPY_VERSION_STR = obspy.__version__
     OBSPY_VERSION = OBSPY_VERSION_STR.split('.')[:3]
     # special case for "rc" versions:

--- a/sourcespec/ssp_setup.py
+++ b/sourcespec/ssp_setup.py
@@ -48,6 +48,10 @@ oldlogfile = None
 logger = None
 ssp_exit_called = False
 traceid_map = None
+# SEED standard instrument codes:
+# https://ds.iris.edu/ds/nodes/dmc/data/formats/seed-channel-naming/
+instr_codes_vel = ['H', 'L']
+instr_codes_acc = ['N', ]
 OBSPY_VERSION = None
 OBSPY_VERSION_STR = None
 NUMPY_VERSION_STR = None
@@ -432,12 +436,6 @@ def _check_mandatory_config_params(config_obj):
         msg = '\n'.join(messages)
         sys.stderr.write(msg + '\n')
         ssp_exit(1)
-
-
-# SEED standard instrument codes:
-# https://ds.iris.edu/ds/nodes/dmc/data/formats/seed-channel-naming/
-instr_codes_vel = ['H', 'L']
-instr_codes_acc = ['N', ]
 
 
 def _init_instrument_codes(config):

--- a/sourcespec/ssp_util.py
+++ b/sourcespec/ssp_util.py
@@ -231,9 +231,19 @@ def remove_instr_response(trace, pre_filt=(0.5, 0.6, 40., 45.)):
     trace.detrend(type='constant')
     # ...and the linear trend
     trace.detrend(type='linear')
+    # Define output units based on nominal units in inventory
+    # Note: ObsPy >= 1.3.0 supports the 'DEF' output unit, which will make
+    #       this step unnecessary
+    if trace.stats.units.lower() == 'm':
+        output = 'DISP'
+    if trace.stats.units.lower() == 'm/s':
+        output = 'VEL'
+    if trace.stats.units.lower() == 'm/s**2':
+        output = 'ACC'
     # Finally remove instrument response,
     # trace is converted to the sensor units
-    trace.remove_response(inventory=inventory, output='DEF', pre_filt=pre_filt)
+    trace.remove_response(
+        inventory=inventory, output=output, pre_filt=pre_filt)
 # -----------------------------------------------------------------------------
 
 

--- a/sourcespec/ssp_util.py
+++ b/sourcespec/ssp_util.py
@@ -209,8 +209,7 @@ def smooth(x, window_len=11, window='hanning'):
     return yy
 
 
-def remove_instr_response(trace, correct='True',
-                          pre_filt=(0.5, 0.6, 40., 45.)):
+def remove_instr_response(trace, pre_filt=(0.5, 0.6, 40., 45.)):
     """
     Remove instrument response from a trace.
 
@@ -220,51 +219,24 @@ def remove_instr_response(trace, correct='True',
 
     :param trace: Trace to be corrected.
     :type trace: :class:`~obspy.core.trace.Trace`
-    :param correct: If ``True``, the instrument response will be corrected.
-        If ``False``, the instrument response will not be corrected.
-        If ``sensitivity_only``, the instrument response will be corrected
-        using only the sensitivity.
-    :type correct: bool or str
     :param pre_filt: Pre-filter frequencies (``None`` means no pre-filtering).
     :type pre_filt: tuple of four floats
     :returns: Corrected trace.
     :rtype: :class:`~obspy.core.trace.Trace`
     """
-    if correct == 'False':
-        return trace
     traceId = trace.get_id()
-    paz = trace.stats.paz
-    if paz is None:
-        logger.warning('{}: no poles and zeros for trace'.format(traceId))
-        return None
-
+    inventory = trace.stats.inventory
+    if not inventory:
+        # empty inventory
+        raise RuntimeError(
+            f'{traceId}: no instrument response for trace')
     # remove the mean...
     trace.detrend(type='constant')
     # ...and the linear trend
     trace.detrend(type='linear')
-
-    # Finally remove instrument response
-    # If we don't have any pole or zero defined,
-    # then be smart and just use the sensitivity ;)
-    if len(paz.poles) == 0 and len(paz.zeros) == 0:
-        correct = 'sensitivity_only'
-    if correct == 'sensitivity_only':
-        trace.data /= paz.sensitivity
-    # Otherwise we need to call trace.simulate(), which is quite slow...
-    else:
-        with warnings.catch_warnings(record=True) as w:
-            # N.B. using "sacsim=True" makes this two times slower!
-            # (because of "c_sac_taper()")
-            # TODO: fill up a bug on obspy.org
-            trace.simulate(paz_remove=paz, paz_simulate=None,
-                           remove_sensitivity=True, simulate_sensitivity=None,
-                           pre_filt=pre_filt, sacsim=False)
-            if len(w) > 0:
-                logger.warning(
-                    '{}: remove_instr_response: {}'.format(
-                        trace.stats.station, w[-1].message)
-                )
-    return trace
+    # Finally remove instrument response,
+    # trace is converted to the sensor units
+    trace.remove_response(inventory=inventory, output='DEF', pre_filt=pre_filt)
 # -----------------------------------------------------------------------------
 
 

--- a/sourcespec/ssp_util.py
+++ b/sourcespec/ssp_util.py
@@ -220,8 +220,6 @@ def remove_instr_response(trace, pre_filt=(0.5, 0.6, 40., 45.)):
     :type trace: :class:`~obspy.core.trace.Trace`
     :param pre_filt: Pre-filter frequencies (``None`` means no pre-filtering).
     :type pre_filt: tuple of four floats
-    :returns: Corrected trace.
-    :rtype: :class:`~obspy.core.trace.Trace`
     """
     traceId = trace.get_id()
     inventory = trace.stats.inventory

--- a/sourcespec/ssp_util.py
+++ b/sourcespec/ssp_util.py
@@ -12,7 +12,6 @@ Utility functions for sourcespec.
 import os
 from glob import glob
 import logging
-import warnings
 import math
 import numpy as np
 from obspy.signal.invsim import cosine_taper as _cos_taper


### PR DESCRIPTION
This PR modernizes the instrument correction routine `remove_instr_response()` which goes from using `trace.simulate()` and poles and zeros to `trace.remove_response()` and full response, as defined in the `Inventory()` object.

In case users provide a PAZ file, this is converted to an `Inventory()` object using a custom routine.

Tested and validated on all my examples.

@krisvanneste, I don't know if you use instrument correction from SourceSpec. If that's the case, I'll wait on your feedback before merging. Thanks!