### PR TITLE
HTML report without images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ Earthquake source parameters from P- or S-wave displacement spectra
 - Logscale for boxplots, if parameters span a large interval
   (see pull request [#15])
 - Information on the inversion procedure in YAML and HTML output
+- Possibility of generating HTML report without figures (see [#30])
 
 ### Processing
 
@@ -484,3 +485,4 @@ Initial Python port.
 [#25]: https://github.com/SeismicSource/sourcespec/issues/25
 [#27]: https://github.com/SeismicSource/sourcespec/issues/27
 [#28]: https://github.com/SeismicSource/sourcespec/issues/28
+[#30]: https://github.com/SeismicSource/sourcespec/issues/30

--- a/sourcespec/html_report_template/index.html
+++ b/sourcespec/html_report_template/index.html
@@ -38,35 +38,35 @@
               &nbsp;&nbsp;
               Event Summary
             </a>
-          </li>
+          </li>{MAP_MAG_COMMENT_BEGIN}
           <li>
             <a href="#moment_magnitude">
               <i class="fas fa-image"></i>
               &nbsp;&nbsp;
               Moment Magnitude
             </a>
-          </li>
+          </li>{MAP_MAG_COMMENT_END}{MAP_FC_COMMENT_BEGIN}
           <li>
             <a href="#corner_frequency">
               <i class="fas fa-image"></i>
               &nbsp;&nbsp;
               Corner Frequency
             </a>
-          </li>
+          </li>{MAP_FC_COMMENT_END}{TRACES_PLOTS_COMMENT_BEGIN}
           <li>
             <a href="#traces">
               <i class="fas fa-image"></i>
               &nbsp;&nbsp;
               Traces
             </a>
-          </li>
+          </li>{TRACES_PLOTS_COMMENT_END}{SPECTRA_PLOTS_COMMENT_BEGIN}
           <li>
             <a href="#spectra">
               <i class="fas fa-image"></i>
               &nbsp;&nbsp;
               Spectra
             </a>
-          </li>
+          </li>{SPECTRA_PLOTS_COMMENT_END}
           <li>
             <a href="#inversion_info">
               <i class="fas fa-table"></i>
@@ -80,37 +80,35 @@
               &nbsp;&nbsp;
               Summary Spectral Parameters
             </a>
-          </li>
+          </li>{BOX_PLOTS_COMMENT_BEGIN}
           <li>
             <a href="#box_plots">
               <i class="fas fa-image"></i>
               &nbsp;&nbsp;
               Spectral Parameter<br>Box Plots
             </a>
-          </li>
+          </li>{BOX_PLOTS_COMMENT_END}{STACKED_SPECTRA_COMMENT_BEGIN}
           <li>
             <a href="#stacked_spectra">
               <i class="fas fa-image"></i>
               &nbsp;&nbsp;
               Stacked Spectra
             </a>
-          </li>
+          </li>{STACKED_SPECTRA_COMMENT_END}
           <li>
             <a href="#station_parameters">
               <i class="fas fa-table"></i>
               &nbsp;&nbsp;
               Station Parameters
             </a>
-          </li>
-{MISFIT_PLOT_COMMENT_BEGIN}
+          </li>{MISFIT_PLOT_COMMENT_BEGIN}
           <li>
             <a href="#misfit_plots">
               <i class="fas fa-image"></i>
               &nbsp;&nbsp;
               Misfit Plots
             </a>
-          </li>
-{MISFIT_PLOT_COMMENT_END}
+          </li>{MISFIT_PLOT_COMMENT_END}
           <li>
             <a href="#files">
               <i class="fas fa-file"></i>
@@ -144,23 +142,17 @@
           <tbody>
             <tr>
               <th scope="row">Event ID:</th>
-              <td>
-{EVENT_URL_COMMENT_BEGIN}
-                <a href="{EVENT_URL}" title="Go to event page" target="_new">
-{EVENT_URL_COMMENT_END}
-                  {EVENTID}
-{EVENT_URL_COMMENT_BEGIN}
+              <td>{EVENT_URL_COMMENT_BEGIN}
+                <a href="{EVENT_URL}" title="Go to event page" target="_new">{EVENT_URL_COMMENT_END}
+                  {EVENTID}{EVENT_URL_COMMENT_BEGIN}
                   &nbsp;<i class="fas fa-external-link-alt"></i>
-                </a>
-{EVENT_URL_COMMENT_END}
+                </a>{EVENT_URL_COMMENT_END}
               </td>
-            </tr>
-{RUNID_COMMENT_BEGIN}
+            </tr>{RUNID_COMMENT_BEGIN}
             <tr>
               <th scope="row">Run ID:</th>
               <td>{RUNID}</td>
-            </tr>
-{RUNID_COMMENT_END}
+            </tr>{RUNID_COMMENT_END}
             <tr>
               <th scope="row">Longitude:</th>
               <td>{EVENT_LONGITUDE} °E</td>
@@ -189,27 +181,35 @@
         </table>
       </div> <!-- page -->
 
+{MAP_MAG_COMMENT_BEGIN}
       <div class="page">
         <div class="line" id="moment_magnitude"></div>
         <h2>Moment Magnitude</h2>
         <div class="item" data-src="{MAP_MAG}">
           <img class="station_map" src="{MAP_MAG}"/>
         </div>
-      </div> <!-- page -->
+      </div>
+{MAP_MAG_COMMENT_END}
 
+{MAP_FC_COMMENT_BEGIN}
       <div class="page">
         <div class="line" id="corner_frequency"></div>
         <h2>Corner Frequency</h2>
         <div class="item" data-src="{MAP_FC}">
           <img class="station_map" src="{MAP_FC}"/>
         </div>
-      </div> <!-- page -->
+      </div>
+{MAP_FC_COMMENT_END}
 
+{TRACES_PLOTS_COMMENT_BEGIN}
       <div class="line" id="traces"></div>
 {TRACES_PLOTS}
+{TRACES_PLOTS_COMMENT_END}
 
+{SPECTRA_PLOTS_COMMENT_BEGIN}
       <div class="line" id="spectra"></div>
 {SPECTRA_PLOTS}
+{SPECTRA_PLOTS_COMMENT_END}
 
       <div class="page">
         <div class="line" id="inversion_info"></div>
@@ -219,49 +219,49 @@
             <tr>
               <th scope="row">Algorithm:</th>
               <td>
-{INVERSION_ALGORITHM}
+                {INVERSION_ALGORITHM}
               </td>
             </tr>
             <tr>
               <th scope="row">Weighting:</th>
               <td>
-{INVERSION_WEIGHTING}
+                {INVERSION_WEIGHTING}
               </td>
             </tr>
             <tr>
               <th scope="row">t-star-0:</th>
               <td>
-{INVERSION_T_STAR_0}
+                {INVERSION_T_STAR_0}
               </td>
             </tr>
             <tr>
               <th scope="row">Invert t-star-0:</th>
               <td>
-{INVERSION_INVERT_T_STAR_0}
+                {INVERSION_INVERT_T_STAR_0}
               </td>
             </tr>
             <tr>
               <th scope="row">t-star-0 variability:</th>
               <td>
-{INVERSION_T_STAR_0_VARIABILITY}
+                {INVERSION_T_STAR_0_VARIABILITY}
               </td>
             </tr>
             <tr>
               <th scope="row">t-star min, max:</th>
               <td>
-{INVERSION_T_STAR_MIN_MAX}
+                {INVERSION_T_STAR_MIN_MAX}
               </td>
             </tr>
             <tr>
               <th scope="row">fc min, max:</th>
               <td>
-{INVERSION_FC_MIN_MAX}
+                {INVERSION_FC_MIN_MAX}
               </td>
             </tr>
             <tr>
               <th scope="row">Qo min, max:</th>
               <td>
-{INVERSION_Q0_MIN_MAX}
+                {INVERSION_Q0_MIN_MAX}
               </td>
             </tr>
           </tbody>
@@ -339,34 +339,36 @@
               <td>{ER_MEAN_AND_ERR}</td>
               <td></td>
               <td>{ER_PERC_AND_ERR}</td>
-            </tr>
-{ML_COMMENT_BEGIN}
+            </tr>{ML_COMMENT_BEGIN}
             <tr>
               <th scope="row">Ml</th>
               <td>{ML_MEAN_AND_ERR}</td>
               <td></td>
               <td>{ML_PERC_AND_ERR}</td>
-            </tr>
-{ML_COMMENT_END}
+            </tr>{ML_COMMENT_END}
           </tbody>
         </table>
       </div> <!-- page -->
 
+{BOX_PLOTS_COMMENT_BEGIN}
       <div class="page">
         <div class="line" id="box_plots"></div>
         <h2>Spectral Parameter Box Plots</h2>
         <div class="item" data-src="{BOX_PLOTS}">
           <img class="box_plot" src="{BOX_PLOTS}"/>
         </div>
-      </div> <!-- page -->
+      </div>
+{BOX_PLOTS_COMMENT_END}
 
+{STACKED_SPECTRA_COMMENT_BEGIN}
       <div class="page">
         <div class="line" id="stacked_spectra"></div>
         <h2>Stacked Spectra</h2>
         <div class="item" data-src="{STACKED_SPECTRA}">
           <img class="stacked_spectra" src="{STACKED_SPECTRA}"/>
         </div>
-      </div> <!-- page -->
+      </div>
+{STACKED_SPECTRA_COMMENT_END}
 
       <div class="page">
         <div class="line" id="station_parameters"></div>
@@ -417,12 +419,10 @@
                 </th>
                 <th onclick="sortTable(11, numeric=true)" scope="col">
                   <nobr><i class="fas fa-sort dontprint_inline"></i>&nbsp;Azimuth</nobr><br/>(°)
-                </th>
-{ML_COMMENT_BEGIN}
+                </th>{ML_COMMENT_BEGIN}
                 <th onclick="sortTable(12, numeric=true)" scope="col">
                   <nobr><i class="fas fa-sort"></i>&nbsp;Ml</nobr>
-                </th>
-{ML_COMMENT_END}
+                </th>{ML_COMMENT_END}
               </tr>
             </thead>
             <tbody>

--- a/sourcespec/html_report_template/station_table_row.html
+++ b/sourcespec/html_report_template/station_table_row.html
@@ -10,8 +10,6 @@
               <td>{STATION_RA}<br/>{STATION_RA_ERR}</td>
               <td>{STATION_ER}</td>
               <td>{STATION_DIST}</td>
-              <td>{STATION_AZ}</td>
-{ML_COMMENT_BEGIN}
-              <td>{STATION_ML}</td>
-{ML_COMMENT_END}
+              <td>{STATION_AZ}</td>{ML_COMMENT_BEGIN}
+              <td>{STATION_ML}</td>{ML_COMMENT_END}
             </tr>

--- a/sourcespec/ssp_setup.py
+++ b/sourcespec/ssp_setup.py
@@ -557,21 +557,13 @@ def configure(options, progname, config_overrides=None):
         if not config.plot_save:
             msg = (
                 'The "html_report" option is selected but "plot_save" '
-                'is "False". Setting "plot_save" to "True".')
+                'is "False". HTML report will have no plots.')
             config.warnings.append(msg)
-            config.plot_save = True
         if config.plot_save_format not in ['png', 'svg']:
             msg = (
                 'The "html_report" option is selected but "plot_save_format" '
-                'is not "png" or "svg". Setting "plot_save_format" to "png".')
+                'is not "png" or "svg". HTML report will have no plots.')
             config.warnings.append(msg)
-            config.plot_save_format = 'png'
-        if not config.plot_station_map:
-            msg = (
-                'The "html_report" option is selected but "plot_station_map" '
-                'is "False". Setting "plot_station_map" to "True".')
-            config.warnings.append(msg)
-            config.plot_station_map = True
 
     if config.plot_station_map:
         try:


### PR DESCRIPTION
I refactored `ssp_html_report.py` to allow generating an HTML report without some or all of the images.

Also, if plots are in PDF format, no images will be added to the HTML report.

This refactoring also splits `ssp_html_report.py` into many smaller functions, for easier readability and maintainability.
