### PR TITLE
Fixes for cases when components of the same instrument have different length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,8 @@ Earthquake source parameters from P- or S-wave displacement spectra
 - Fix a bug in generating evid form origin time when reading origin time from
   SAC header and the number of seconds was 59
 - Fix a crash when no map tiles were available at the selected zoom level
+- Fix for a corner case where the three components of the same instrument
+  have different trace length (see [#31])
 - Fix `source_residuals`, which didn't work anymore
 
 ## v1.6 - 2022-08-02
@@ -492,3 +494,4 @@ Initial Python port.
 [#27]: https://github.com/SeismicSource/sourcespec/issues/27
 [#28]: https://github.com/SeismicSource/sourcespec/issues/28
 [#30]: https://github.com/SeismicSource/sourcespec/issues/30
+[#31]: https://github.com/SeismicSource/sourcespec/issues/31

--- a/sourcespec/configspec.conf
+++ b/sourcespec/configspec.conf
@@ -466,7 +466,7 @@ plot_spectra_no_fc = boolean(default=False)
 # Max number of rows in plots
 plot_spectra_maxrows = integer(min=1, default=3)
 plot_traces_maxrows = integer(min=1, default=3)
-# Plot ignored traces (low S/N)
+# Plot ignored traces (clipped or low S/N)
 plot_traces_ignored = boolean(default=True)
 # Plot ignored spectra (low S/N)
 plot_spectra_ignored = boolean(default=True)

--- a/sourcespec/ssp_build_spectra.py
+++ b/sourcespec/ssp_build_spectra.py
@@ -516,6 +516,7 @@ def _check_spectral_sn_ratio(config, spec, specnoise):
     weight = _build_weight_from_noise(config, spec, specnoise)
     # if no noise window is available, snratio is not computed
     if weight.snratio is None:
+        spec.stats.spectral_snratio = None
         return
     if config.spectral_sn_freq_range is not None:
         sn_fmin, sn_fmax = config.spectral_sn_freq_range

--- a/sourcespec/ssp_plot_spectra.py
+++ b/sourcespec/ssp_plot_spectra.py
@@ -438,6 +438,8 @@ def _add_legend(config, plot_params, spec_st, specnoise_st):
 
 def _snratio_text(spec, ax, color, path_effects):
     global snratio_text_ypos
+    if spec.stats.spectral_snratio is None:
+        return
     snratio_text = f'S/N: {spec.stats.spectral_snratio:.1f}'
     ax.text(
         0.95, snratio_text_ypos, snratio_text, ha='right', va='top',


### PR DESCRIPTION
I stumbled upon some corner case, where components of the same instrument have different length.

For that, I had to:

1. Make sure that noise and signal windows have the same number of points for all the components
2. Make sure that trace plots are correctly aligned

I also took the opportunity to add a fix which correctly plots signal and noise windows when the signal window is truncated to the noise length or when the noise window is padded to the signal length.

As always, I'm asking @krisvanneste to double-check, especially because this touches some of the changes he introduced. Thank you!