### PR TITLE
Inverse-frequency weighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,16 @@ This release requires at least Python 3.7.
   (hypocentral location, magnitude, focal mechanism, moment tensor):
   the [SourceSpec Event File].
 
+### Processing
+
+- New weighting option based on inverse frequency, so that lower frequencies
+  have larger weight in the inversion. If traces contain noise, weights will
+  be set to zero where SNR < 3 (see [#37])
+
+### Config file
+
+- New option `inv_frequency` for the config parameter `weighting` (see [#37])
+
 ### Bugfixes
 
 - Do not ignore picks labeled with lowercase "p" or "s"
@@ -551,4 +561,5 @@ Initial Python port.
 [#30]: https://github.com/SeismicSource/sourcespec/issues/30
 [#31]: https://github.com/SeismicSource/sourcespec/issues/31
 [#35]: https://github.com/SeismicSource/sourcespec/issues/35
+[#37]: https://github.com/SeismicSource/sourcespec/issues/37
 [#40]: https://github.com/SeismicSource/sourcespec/issues/40

--- a/sourcespec/config_files/configspec.conf
+++ b/sourcespec/config_files/configspec.conf
@@ -319,8 +319,19 @@ geom_spread_cutoff_distance = float(min=0, default=100)
 
 # INVERSION PARAMETERS --------
 # Weighting type: 'noise', 'frequency', 'inv_frequency' or 'no_weight'
-weighting = option('noise', 'frequency', 'no_weight', default='noise')
-# Parameters for 'frequency' weighting (ignored for 'noise' weighting):
+#   'noise':         spectral signal/noise ratio weighting
+#   'frequency':     a constant weight is applied for f<=f_weight
+#                    a weight of 1 is used for f>f_weight
+#                    (see "f_weight" and "weight" below)
+#   'inv_frequency': weight is computed as 1/(f-f0+0.25)**0.25 for f<=f1,
+#                    weight is 0 for f<f0 and f>f1.
+#                    f0 and f1 are the first and last frequencies where
+#                    spectral signal/noise ratio is above 3, or the first and
+#                    last frequencies of the entire spectrum if no noise window
+#                    is available
+#   'no_weight':     no weighting
+weighting = option('noise', 'frequency', 'inv_frequency', 'no_weight', default='noise')
+# Parameters for 'frequency' weighting (ignored for the other weighting types):
 #   weight for f<=f_weight (Hz)
 #   1      for f> f_weight (Hz)
 f_weight = float(min=0, default=7.)

--- a/sourcespec/config_files/configspec.conf
+++ b/sourcespec/config_files/configspec.conf
@@ -318,7 +318,7 @@ geom_spread_cutoff_distance = float(min=0, default=100)
 
 
 # INVERSION PARAMETERS --------
-# Weighting type: 'noise', 'frequency' or 'no_weight'
+# Weighting type: 'noise', 'frequency', 'inv_frequency' or 'no_weight'
 weighting = option('noise', 'frequency', 'no_weight', default='noise')
 # Parameters for 'frequency' weighting (ignored for 'noise' weighting):
 #   weight for f<=f_weight (Hz)
@@ -354,7 +354,8 @@ inv_algorithm = option('TNC', 'LM', 'BH', 'GS', 'IS', default='TNC')
 # 2. If not specified, fc bounds will be autoset to fc0/10 and fc0*10, i.e. two
 #    decades around fc0. The value of fc0 is set as the first maximum of
 #    spectral S/N (noise weighting), or at "f_weight" (frequency weighting),
-#    or at half of the frequency window (no weighting)
+#    or at frequency where weight is 30% below the maximum (inverse-frequency
+#    weighting) or at half of the frequency window (no weighting)
 # 3. Specify bounds as a list, ex.:
 #      fc_min_max = 0.1, 40
 #    (comment out or use None to indicate no bound)

--- a/sourcespec/ssp_build_spectra.py
+++ b/sourcespec/ssp_build_spectra.py
@@ -411,7 +411,7 @@ def _build_weight_from_frequency(config, spec):
     return weight
 
 
-def _build_weight_from_inv_frequency(config, spec, pow=0.25):
+def _build_weight_from_inv_frequency(spec, pow=0.25):
     """
     Build spectral weights from inverse frequency (raised to a power < 1)
     """
@@ -494,7 +494,7 @@ def _build_weight_spectral_stream(config, spec_st, specnoise_st):
         elif config.weighting == 'frequency':
             weight = _build_weight_from_frequency(config, spec_h)
         elif config.weighting == 'inv_frequency':
-            weight = _build_weight_from_inv_frequency(config, spec_h)
+            weight = _build_weight_from_inv_frequency(spec_h)
         elif config.weighting == 'no_weight':
             weight = _build_uniform_weight(spec_h)
         weight_st.append(weight)

--- a/sourcespec/ssp_build_spectra.py
+++ b/sourcespec/ssp_build_spectra.py
@@ -415,6 +415,8 @@ def _build_weight_from_inv_frequency(spec, pow=0.25):
     """
     Build spectral weights from inverse frequency (raised to a power < 1)
     """
+    if pow >= 1:
+        raise ValueError('pow must be < 1')
     # Note: weight.data is used for plotting, weight.data_log for actual weighting
     weight = spec.copy()
     freq = weight.get_freq()

--- a/sourcespec/ssp_build_spectra.py
+++ b/sourcespec/ssp_build_spectra.py
@@ -147,7 +147,7 @@ def _check_data_len(config, trace):
             f'{traceId}: No data for the selected cut interval: '
             'skipping trace')
     nzeros = len(np.where(trace_cut.data == 0)[0])
-    if nzeros > npts/4:
+    if nzeros > npts / 4:
         raise RuntimeError(
             f'{traceId}: Signal window is zero for more than 25%: '
             'skipping trace')
@@ -238,7 +238,10 @@ def _check_noise_level(trace_signal, trace_noise, config):
     except ZeroDivisionError:
         scale_factor = 1
     trace_noise_rms = ((trace_noise.data**2 * scale_factor).sum())**0.5
-    if trace_noise_rms/trace_signal_rms < 1e-6 and config.weighting == 'noise':
+    if (
+        trace_noise_rms / trace_signal_rms < 1e-6 and
+        config.weighting == 'noise'
+    ):
         # Skip trace if noise level is too low and if noise weighting is used
         raise RuntimeError(
             f'{traceId}: Noise level is too low or zero: '
@@ -272,9 +275,9 @@ def _boatwright_above_cutoff_dist(freqs, cutoff_dist, dist):
     mid_freq = np.logical_and(freqs > 0.2, freqs <= 0.25)
     high_freq = freqs >= 0.25
     exponent[low_freq] = 0.5
-    exponent[mid_freq] = 0.5 + 2*np.log(5*freqs[mid_freq])
+    exponent[mid_freq] = 0.5 + 2 * np.log(5 * freqs[mid_freq])
     exponent[high_freq] = 0.7
-    return cutoff_dist * (dist/cutoff_dist)**exponent
+    return cutoff_dist * (dist / cutoff_dist)**exponent
 
 
 def _geometrical_spreading_coefficient(config, spec):
@@ -317,7 +320,7 @@ def _displacement_to_moment(stats, config):
         velocity_log_messages.append(msg)
     v_hypo *= 1000.
     v_station *= 1000.
-    v3 = v_hypo**(5./2) * v_station**(1./2)
+    v3 = v_hypo**(5. / 2) * v_station**(1. / 2)
     rp = get_radiation_pattern_coefficient(stats, config)
     return 4 * math.pi * v3 * config.rho / (2 * rp)
 
@@ -330,14 +333,14 @@ def _smooth_spectrum(spec, smooth_width_decades=0.2):
     # frequencies in logarithmic spacing
     log_df = _log_freq[-1] - _log_freq[-2]
     freq_logspace =\
-        10**(np.arange(_log_freq[0], _log_freq[-1]+log_df, log_df))
+        10**(np.arange(_log_freq[0], _log_freq[-1] + log_df, log_df))
     # 2. Reinterpolate data using log10 frequencies
     # make sure that extrapolation does not create negative values
     f = interp1d(freq, spec.data, fill_value='extrapolate')
     data_logspace = f(freq_logspace)
     data_logspace[data_logspace <= 0] = np.min(spec.data)
     # 3. Smooth log10-spaced data points
-    npts = max(1, int(round(smooth_width_decades/log_df)))
+    npts = max(1, int(round(smooth_width_decades / log_df)))
     data_logspace = smooth(data_logspace, window_len=npts)
     # 4. Reinterpolate to linear frequencies
     # make sure that extrapolation does not create negative values
@@ -348,9 +351,9 @@ def _smooth_spectrum(spec, smooth_width_decades=0.2):
     # 5. Optimize the sampling rate of log spectrum,
     #    based on the width of the smoothing window
     # make sure that extrapolation does not create negative values
-    log_df = smooth_width_decades/5
+    log_df = smooth_width_decades / 5
     freq_logspace =\
-        10**(np.arange(_log_freq[0], _log_freq[-1]+log_df, log_df))
+        10**(np.arange(_log_freq[0], _log_freq[-1] + log_df, log_df))
     spec.freq_log = freq_logspace
     data_logspace = f(freq_logspace)
     data_logspace[data_logspace <= 0] = np.min(spec.data)
@@ -419,30 +422,20 @@ def _build_weight_from_inv_frequency(config, spec, pow=0.25):
     # Limit non-zero weights to fmin/fmax from spectral_snratio if available
     snr_fmin = getattr(spec.stats, 'spectral_snratio_fmin', None)
     snr_fmax = getattr(spec.stats, 'spectral_snratio_fmax', None)
-    if snr_fmin:
-        i0 = np.where(freq >= snr_fmin)[0][0]
-    else:
-        i0 = 0
-    if snr_fmax:
-        i1 = np.where(freq <= snr_fmax)[0][-1]
-    else:
-        i1 = len(freq) - 1
+    i0 = np.where(freq >= snr_fmin)[0][0] if snr_fmin else 0
+    i1 = np.where(freq <= snr_fmax)[0][-1] if snr_fmax else len(freq) - 1
     # Build weights as if frequencies always start from 0.25 Hz
     # to obtain similar curves regardless of fmin
     # and to avoid too much weight for very low frequencies
-    weight.data[i0:i1+1] = 1. / (freq[i0:i1+1] - freq[i0] + 0.25)**pow
+    weight.data[i0: i1 + 1] = 1. / (freq[i0: i1 + 1] - freq[i0] + 0.25)**pow
     weight.data /= np.max(weight.data)
     freq_log = weight.freq_log
     weight.data_log *= 0
-    if snr_fmin:
-        i0 = np.where(freq_log >= snr_fmin)[0][0]
-    else:
-        i0 = 0
-    if snr_fmax:
-        i1 = np.where(freq_log <= snr_fmax)[0][-1]
-    else:
-        i1 = len(freq_log) - 1
-    weight.data_log[i0:i1+1] = 1. / (freq_log[i0:i1+1]-freq_log[i0]+0.25)**pow
+    i0 = np.where(freq_log >= snr_fmin)[0][0] if snr_fmin else 0
+    i1 = np.where(freq_log <= snr_fmax)[0][-1] if snr_fmax\
+        else len(freq_log) - 1
+    weight.data_log[i0: i1 + 1] =\
+        1. / (freq_log[i0: i1 + 1] - freq_log[i0] + 0.25)**pow
     weight.data_log /= np.max(weight.data_log)
     return weight
 
@@ -460,7 +453,7 @@ def _build_weight_from_ratio(spec, specnoise, smooth_width_decades):
     weight.data /= np.max(weight.data)
     # slightly taper weight at low frequencies, to avoid overestimating
     # weight at low frequencies, in cases where noise is underestimated
-    cosine_taper(weight.data, weight.stats.delta/4, left_taper=True)
+    cosine_taper(weight.data, weight.stats.delta / 4, left_taper=True)
     # Make sure weight is positive
     weight.data[weight.data <= 0] = 0.001
     return weight
@@ -511,7 +504,7 @@ def _build_weight_spectral_stream(config, spec_st, specnoise_st):
 def _select_spectra(spec_st, specid):
     """Select spectra from stream, based on specid."""
     network, station, location, channel = specid.split('.')
-    channel = channel + '?'*(3-len(channel))
+    channel = channel + '?' * (3 - len(channel))
     spec_st_sel = spec_st.select(
         network=network, station=station, location=location, channel=channel)
     spec_st_sel = Stream(sp for sp in spec_st_sel if not sp.stats.ignore)
@@ -552,11 +545,10 @@ def _check_spectral_sn_ratio(config, spec, specnoise):
     if config.spectral_sn_freq_range is not None:
         sn_fmin, sn_fmax = config.spectral_sn_freq_range
         freqs = weight.get_freq()
-        idx = np.where((sn_fmin <= freqs)*(freqs <= sn_fmax))
+        idx = np.where((sn_fmin <= freqs) * (freqs <= sn_fmax))
     else:
         idx = range(len(weight.snratio))
-    spectral_snratio =\
-        weight.snratio[idx].sum()/len(weight.snratio[idx])
+    spectral_snratio = weight.snratio[idx].sum() / len(weight.snratio[idx])
     spec.stats.spectral_snratio = spectral_snratio
     # Save frequency range where SNR > 3 so it can be used for building weights
     # Note: not sure if we could use config.spectral_sn_min here instead of 3
@@ -565,7 +557,7 @@ def _check_spectral_sn_ratio(config, spec, specnoise):
     try:
         spec.stats.spectral_snratio_fmin = snr_valid_freqs[0]
         spec.stats.spectral_snratio_fmax = snr_valid_freqs[-1]
-    except:
+    except IndexError:
         spec.stats.spectral_snratio_fmin = None
         spec.stats.spectral_snratio_fmax = None
     spec_id = spec.get_id()
@@ -695,7 +687,7 @@ def _zero_pad(config, trace):
         t1 = trace.stats.arrivals[f'{wtype}1'][1]
     elif trace.stats.type == 'noise':
         t1 = trace.stats.arrivals['N1'][1]
-    trace.trim(starttime=t1, endtime=t1+spec_win_len, pad=True, fill_value=0)
+    trace.trim(starttime=t1, endtime=t1 + spec_win_len, pad=True, fill_value=0)
 
 
 def build_spectra(config, st):

--- a/sourcespec/ssp_data_types.py
+++ b/sourcespec/ssp_data_types.py
@@ -94,7 +94,7 @@ class Bounds(object):
     def _Qo_to_t_star(self):
         phase = self.config.wave_type[0]
         travel_time = self.spec.stats.travel_times[phase]
-        t_star_bounds = travel_time/self.config.Qo_min_max
+        t_star_bounds = travel_time/np.array(self.config.Qo_min_max)
         return sorted(t_star_bounds)
 
     def _fix_initial_values_t_star(self):

--- a/sourcespec/ssp_html_report.py
+++ b/sourcespec/ssp_html_report.py
@@ -520,6 +520,7 @@ def _add_inversion_info_to_html(sspec_output, replacements):
     weightings = {
         'noise': 'Noise weighting',
         'frequency': 'Frequency weighting',
+        'inv_frequency': 'Inverse frequency weighting',
         'no_weight': 'No weighting',
     }
     inversion_algorithm = inversion_algorithms[

--- a/sourcespec/ssp_inversion.py
+++ b/sourcespec/ssp_inversion.py
@@ -152,6 +152,9 @@ def _freq_ranges_for_Mw0_and_tstar0(config, weight, freq_log, statId):
         idx0 = 0
         # the closest index to f_weight:
         idx1 = np.where(freq_log <= config.f_weight)[0][-1]
+    elif config.weighting == 'inv_frequency':
+        idx0 = 0
+        idx1 = np.where(weight < 0.7)[0][0]
     else:
         idx0 = 0
         idx1 = len(weight) // 2
@@ -403,6 +406,7 @@ def spectral_inversion(config, spec_st, weight_st):
     weighting_messages = {
         'noise': 'Using noise weighting for inversion.',
         'frequency': 'Using frequency weighting for inversion.',
+        'inv_frequency': 'Using inverse frequency weighting for inversion.',
         'no_weight': 'Using no weighting for inversion.'
     }
     logger.info(weighting_messages[config.weighting])

--- a/sourcespec/ssp_inversion.py
+++ b/sourcespec/ssp_inversion.py
@@ -153,8 +153,15 @@ def _freq_ranges_for_Mw0_and_tstar0(config, weight, freq_log, statId):
         # the closest index to f_weight:
         idx1 = np.where(freq_log <= config.f_weight)[0][-1]
     elif config.weighting == 'inv_frequency':
-        idx0 = 0
-        idx1 = np.where(weight < 0.7)[0][0]
+        weight_idxs = np.where(weight >= 0.7)[0]
+        try:
+            idx0 = weight_idxs[0]
+        except IndexError:
+            idx0 = 0
+        try:
+            idx1 = weight_idxs[-1]
+        except IndexError:
+            idx1 = len(weight) - 1
     else:
         idx0 = 0
         idx1 = len(weight) // 2


### PR DESCRIPTION
Claudio,

I implemented a third weighting option in sourcespec based on inverse frequency, so that lower frequencies have larger weight in the inversion. If traces contain noise, weights will be set to zero where SNR < 3.

Note that the weights are not strictly 1/f, but 1/(f-f0+0.25)**0.25 (with f0 corresponding to the first valid frequency in the spectrum). This ensures that the weight curves have a similar shape, regardless of the actual frequency range, and also that the few lowest frequencies do not receive extremely large weights with respect to the others.

Here is a plot showing what the spectral weights look like:
![1306 sspweight 00](https://github.com/SeismicSource/sourcespec/assets/2128835/e5d4259a-3b9a-417a-b32a-9f9b16af5846)

Could you run a test with your data to see how it behaves?

I also fixed a small bug which appears when setting the Qo_min_max configuration parameter. It's a separate commit, so you could also cherry-pick it.

Let me know what you think and if you can think of any improvements, let me know!

Kris