### PR TITLE
Fixes related to records with short signal windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,7 @@ This release requires at least Python 3.7.
   instead of `s_arrival_tolerance` (see [#35])
 - Fix bug where signal and noise windows were plotted with the wrong length,
   under certain circumstances (see [#35])
+- Fixes related to records with short signal windows (see [#39])
 - Fix for beachball not plotted anymore with recent versions of Matplotlib.
 - Fix bug where traces ignored because of low spectral S/N ratio, where still
   plotted as if they were valid traces
@@ -566,4 +567,5 @@ Initial Python port.
 [#35]: https://github.com/SeismicSource/sourcespec/issues/35
 [#37]: https://github.com/SeismicSource/sourcespec/issues/37
 [#38]: https://github.com/SeismicSource/sourcespec/issues/38
+[#39]: https://github.com/SeismicSource/sourcespec/issues/39
 [#40]: https://github.com/SeismicSource/sourcespec/issues/40

--- a/sourcespec/ssp_build_spectra.py
+++ b/sourcespec/ssp_build_spectra.py
@@ -417,7 +417,8 @@ def _build_weight_from_inv_frequency(spec, pow=0.25):
     """
     if pow >= 1:
         raise ValueError('pow must be < 1')
-    # Note: weight.data is used for plotting, weight.data_log for actual weighting
+    # Note: weight.data is used for plotting,
+    #       weight.data_log for actual weighting
     weight = spec.copy()
     freq = weight.get_freq()
     weight.data *= 0
@@ -455,7 +456,10 @@ def _build_weight_from_ratio(spec, specnoise, smooth_width_decades):
     weight.data /= np.max(weight.data)
     # slightly taper weight at low frequencies, to avoid overestimating
     # weight at low frequencies, in cases where noise is underestimated
-    cosine_taper(weight.data, weight.stats.delta / 4, left_taper=True)
+    cosine_taper(
+        weight.data,
+        min(0.25, weight.stats.delta / 4),
+        left_taper=True)
     # Make sure weight is positive
     weight.data[weight.data <= 0] = 0.001
     return weight

--- a/sourcespec/ssp_process_traces.py
+++ b/sourcespec/ssp_process_traces.py
@@ -274,7 +274,7 @@ def _define_signal_and_noise_windows(config, trace):
     # Signal window for spectral analysis (P phase)
     t1 = p_arrival_time - config.signal_pre_time
     t1 = max(trace.stats.starttime, t1)
-    t2 = t1 + min(config.win_length, s_minus_p)
+    t2 = t1 + min(config.win_length, s_minus_p + s_pre_time)
     trace.stats.arrivals['P1'] = ('P1', t1)
     trace.stats.arrivals['P2'] = ('P2', t2)
     # Noise window for spectral analysis


### PR DESCRIPTION
Two minor fixes related to records with short signal windows, which I encountered when running sourcespec on my collection of events:
- fix to avoid taper length gets too large in _build_weight_from_ratio function.
- fix to improve end time of P window in _define_signal_and_noise_windows function.

Here is an illustration of the second case before and after:
![905 traces](https://github.com/SeismicSource/sourcespec/assets/2128835/3236ee2d-0e44-465b-8ed0-db4763bb2f68)

![905 traces](https://github.com/SeismicSource/sourcespec/assets/2128835/ca390498-7335-49bd-8610-11f3ed20843a)

