### PR TITLE
Variable window length

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,8 @@ previous versions. You will need to upgrade your old database manually or using
 - For weights computed from spectral S/N ratio (noise weighting), set to zero
   all the weights below 20% of the maximum weight, so that these weakly
   constrained parts of the spectrum are ignored in the inversion
+- Possibility of using variable signal window lengths for each station
+  as a function of the travel time of the P or S wave (see [#48])
 
 ### Inversion
 
@@ -153,6 +155,8 @@ previous versions. You will need to upgrade your old database manually or using
 - New parameter `plot_map_api_key` to provide a Stadia Maps
   api key for Stamen Terrain basemap
 - New option for the parameter `plot_coastline_resolution`: `no_coastline`
+- New config parameter `variable_win_length_factor` to specify window
+  length as a fraction of the travel time of the P/S wave (see [#48])
 
 ### Bugfixes
 
@@ -706,4 +710,5 @@ Initial Python port.
 [#40]: https://github.com/SeismicSource/sourcespec/issues/40
 [#43]: https://github.com/SeismicSource/sourcespec/issues/43
 [#44]: https://github.com/SeismicSource/sourcespec/issues/44
+[#48]: https://github.com/SeismicSource/sourcespec/issues/48
 [#49]: https://github.com/SeismicSource/sourcespec/issues/49

--- a/sourcespec/config_files/configspec.conf
+++ b/sourcespec/config_files/configspec.conf
@@ -127,7 +127,8 @@ p_arrival_tolerance = float(min=0, default=4.0)
 s_arrival_tolerance = float(min=0, default=4.0)
 
 # Start time (in seconds) of the noise window, respect to the P window
-# If None, it will be set to the length of the signal (P or S) window
+# If None, it will be set to the length of the signal (P or S) window plus
+# the value of "signal_pre_time" (see below)
 noise_pre_time = float(min=0.01, default=6.0)
 
 # Start time (in seconds) of the signal window, respect to the P or S arrival

--- a/sourcespec/config_files/configspec.conf
+++ b/sourcespec/config_files/configspec.conf
@@ -126,8 +126,9 @@ NLL_time_dir = string(default=None)
 p_arrival_tolerance = float(min=0, default=4.0)
 s_arrival_tolerance = float(min=0, default=4.0)
 
-# Start time (in seconds) of the noise window, respect to the P arrival time
-noise_pre_time = float(default=6.0)
+# Start time (in seconds) of the noise window, respect to the P window
+# If None, it will be set to the length of the signal (P or S) window
+noise_pre_time = float(min=0.01, default=6.0)
 
 # Start time (in seconds) of the signal window, respect to the P or S arrival
 # times (see "wave_type" below)

--- a/sourcespec/config_files/configspec.conf
+++ b/sourcespec/config_files/configspec.conf
@@ -136,6 +136,10 @@ signal_pre_time = float(default=1.0)
 
 # Length (in seconds) for both noise and signal windows
 win_length = float(min=0, default=5.0)
+# Variable window length factor (fraction of travel time):
+#   win_length = max(win_length, variable_win_length_factor * travel_time)
+# Set to None to disable variable window length.
+variable_win_length_factor = float(min=0.01, default=None)
 # -------- TIME WINDOW PARAMETERS
 
 

--- a/sourcespec/ssp_plot_spectra.py
+++ b/sourcespec/ssp_plot_spectra.py
@@ -539,9 +539,10 @@ def _params_text(spec, ax, color, path_effects, stack_plots):
         sep = ' '
     params_text = (
         f'{Mo_text} {Mw_text}\n'
-        f'{fc_text}{sep}{t_star_text}\n'
-        f'{Er_text}'
+        f'{fc_text}{sep}{t_star_text}'
     )
+    if Er_text:
+        params_text += f'\n{Er_text}'
     ax.text(
         0.05, params_text_ypos, params_text,
         horizontalalignment='left',

--- a/sourcespec/ssp_plot_traces.py
+++ b/sourcespec/ssp_plot_traces.py
@@ -333,8 +333,8 @@ def _set_ylim(axes):
 
 def _trim_traces(config, st):
     for trace in st:
-        t1 = trace.stats.arrivals['P'][1] - config.noise_pre_time
-        t2 = trace.stats.arrivals['S'][1] + 3 * config.win_length
+        t1 = trace.stats.arrivals['N1'][1]
+        t2 = trace.stats.arrivals['S2'][1] + 2 * config.win_length
         trace.trim(starttime=t1, endtime=t2)
     # compute time offset for correctly aligning traces when plotting
     min_starttime = min(tr.stats.starttime for tr in st)

--- a/sourcespec/ssp_process_traces.py
+++ b/sourcespec/ssp_process_traces.py
@@ -316,6 +316,8 @@ def _define_signal_and_noise_windows(config, trace):
         win_length = win_length_p
     elif config.wave_type[0] == 'S':
         win_length = win_length_s
+    if config.variable_win_length_factor:
+        logger.info(f'{trace.id}: window length {win_length:.3f} seconds')
     # use win_length if noise_pre_time is None
     noise_pre_time = config.noise_pre_time or win_length
     t1 = max(

--- a/sourcespec/ssp_process_traces.py
+++ b/sourcespec/ssp_process_traces.py
@@ -310,12 +310,12 @@ def _define_signal_and_noise_windows(config, trace):
         win_length = win_length_p
     elif config.wave_type[0] == 'S':
         win_length = win_length_s
-    t1 = max(trace.stats.starttime, p_arrival_time - config.noise_pre_time)
+    t1 = max(trace.stats.starttime,
+            p_arrival_time - config.noise_pre_time - config.signal_pre_time)
     t2 = t1 + win_length
-    if t2 >= p_arrival_time:
+    if t2 >= (p_arrival_time - config.signal_pre_time):
         logger.warning(f'{trace.id}: noise window ends after P-wave arrival')
-        # Note: maybe we should also take into account signal_pre_time here
-        t2 = p_arrival_time
+        t2 = p_arrival_time - config.signal_pre_time
         t1 = min(t1, t2)
     trace.stats.arrivals['N1'] = ('N1', t1)
     trace.stats.arrivals['N2'] = ('N2', t2)

--- a/sourcespec/ssp_process_traces.py
+++ b/sourcespec/ssp_process_traces.py
@@ -292,7 +292,11 @@ def _define_signal_and_noise_windows(config, trace):
             'Using (Ts-Tp)/2 instead')
     t1 = s_arrival_time - s_pre_time
     t1 = max(trace.stats.starttime, t1)
-    t2 = t1 + config.win_length
+    tt_s = trace.stats.travel_times['S']
+    # manage case where variable_win_length_factor is None:
+    variable_win_length_factor = config.variable_win_length_factor or 0
+    win_length_s = max(config.win_length, variable_win_length_factor * tt_s)
+    t2 = t1 + win_length_s
     t2 = min(trace.stats.endtime, t2)
     win_length_s = t2 - t1
     trace.stats.arrivals['S1'] = ('S1', t1)
@@ -300,7 +304,9 @@ def _define_signal_and_noise_windows(config, trace):
     # Signal window for spectral analysis (P phase)
     t1 = p_arrival_time - config.signal_pre_time
     t1 = max(trace.stats.starttime, t1)
-    t2 = t1 + min(config.win_length, s_minus_p + s_pre_time)
+    tt_p = trace.stats.travel_times['P']
+    win_length_p = max(config.win_length, variable_win_length_factor * tt_p)
+    t2 = t1 + min(win_length_p, s_minus_p + s_pre_time)
     t2 = min(trace.stats.endtime, t2)
     win_length_p = t2 - t1
     trace.stats.arrivals['P1'] = ('P1', t1)

--- a/sourcespec/ssp_process_traces.py
+++ b/sourcespec/ssp_process_traces.py
@@ -325,8 +325,8 @@ def _define_signal_and_noise_windows(config, trace):
         p_arrival_time - noise_pre_time - config.signal_pre_time
     )
     t2 = t1 + win_length
-    if t2 >= (p_arrival_time - config.signal_pre_time):
-        logger.warning(f'{trace.id}: noise window ends after P-wave arrival')
+    if t2 > (p_arrival_time - config.signal_pre_time):
+        logger.warning(f'{trace.id}: noise window ends after P-window start')
         t2 = p_arrival_time - config.signal_pre_time
         t1 = min(t1, t2)
     trace.stats.arrivals['N1'] = ('N1', t1)

--- a/sourcespec/ssp_process_traces.py
+++ b/sourcespec/ssp_process_traces.py
@@ -318,11 +318,13 @@ def _define_signal_and_noise_windows(config, trace):
         win_length = win_length_s
     if config.variable_win_length_factor:
         logger.info(f'{trace.id}: window length {win_length:.3f} seconds')
-    # use win_length if noise_pre_time is None
-    noise_pre_time = config.noise_pre_time or win_length
+    if config.noise_pre_time is None:
+        noise_pre_time = win_length + config.signal_pre_time
+    else:
+        noise_pre_time = config.noise_pre_time
     t1 = max(
         trace.stats.starttime,
-        p_arrival_time - noise_pre_time - config.signal_pre_time
+        p_arrival_time - noise_pre_time
     )
     t2 = t1 + win_length
     if t2 > (p_arrival_time - config.signal_pre_time):

--- a/sourcespec/ssp_process_traces.py
+++ b/sourcespec/ssp_process_traces.py
@@ -310,8 +310,12 @@ def _define_signal_and_noise_windows(config, trace):
         win_length = win_length_p
     elif config.wave_type[0] == 'S':
         win_length = win_length_s
-    t1 = max(trace.stats.starttime,
-            p_arrival_time - config.noise_pre_time - config.signal_pre_time)
+    # use win_length if noise_pre_time is None
+    noise_pre_time = config.noise_pre_time or win_length
+    t1 = max(
+        trace.stats.starttime,
+        p_arrival_time - noise_pre_time - config.signal_pre_time
+    )
     t2 = t1 + win_length
     if t2 >= (p_arrival_time - config.signal_pre_time):
         logger.warning(f'{trace.id}: noise window ends after P-wave arrival')

--- a/sourcespec/ssp_process_traces.py
+++ b/sourcespec/ssp_process_traces.py
@@ -293,17 +293,25 @@ def _define_signal_and_noise_windows(config, trace):
     t1 = s_arrival_time - s_pre_time
     t1 = max(trace.stats.starttime, t1)
     t2 = t1 + config.win_length
+    t2 = min(trace.stats.endtime, t2)
+    win_length_s = t2 - t1
     trace.stats.arrivals['S1'] = ('S1', t1)
     trace.stats.arrivals['S2'] = ('S2', t2)
     # Signal window for spectral analysis (P phase)
     t1 = p_arrival_time - config.signal_pre_time
     t1 = max(trace.stats.starttime, t1)
     t2 = t1 + min(config.win_length, s_minus_p + s_pre_time)
+    t2 = min(trace.stats.endtime, t2)
+    win_length_p = t2 - t1
     trace.stats.arrivals['P1'] = ('P1', t1)
     trace.stats.arrivals['P2'] = ('P2', t2)
     # Noise window for spectral analysis
+    if config.wave_type[0] == 'P':
+        win_length = win_length_p
+    elif config.wave_type[0] == 'S':
+        win_length = win_length_s
     t1 = max(trace.stats.starttime, p_arrival_time - config.noise_pre_time)
-    t2 = t1 + config.win_length
+    t2 = t1 + win_length
     if t2 >= p_arrival_time:
         logger.warning(f'{trace.id}: noise window ends after P-wave arrival')
         # Note: maybe we should also take into account signal_pre_time here


### PR DESCRIPTION
Claudio,

Here is a first implementation of variable window length as a function of travel time (or equivalently distance).

It contains the following modifications:
- Constrain end time of P and S windows to end time of waveform data: this may not be strictly necessary as exceeding the end time of the record will result in zero padding, but it allows limiting the noise window to the same length as the signal (P or S) window
- Take into account `signal_pre_time` for definition of noise window (there was a note that this should probably be done)
- Do not warn if noise window ends exactly at start of P window and updated warning message accordingly
- Set `noise_pre_time` to noise window length if it is not specified or zero (so it can be different for each record if variable window lengths are used)
- Added `variable_win_length_factor` configuration parameter and use it to calculate window length from travel time of considered phase, while keeping `win_length` as the minimum value
- Trim traces in trace plot to real start of noise window and real end of S window (plus some margin)
- Write variable window length to log file

There are also 2 commits that are not directly related to variable window length, but they address issues I ran into while testing:
- If the radiated energy can't be computed for a record, then plotting of the spectra results in an obscure matplotlib error (maybe because my version is too old). I made a modification to prevent a trailing newline in the label text when the Er label is empty, which avoids this error.
- When examining the reason why no Er could be computed, I found out that computation of the spectral integral is very sensitive to the `fmax` parameter (default None). In cases where the noise spectrum lies above the signal spectrum at the highest frequencies, `noise_integral` becomes quickly higher than `signal_integral`. I fixed this by setting fmax from `spectral_snratio_fmax` (available in the header of the signal spectrum) when fmax is not specified or zero. I can document this problem with a plot and manual calculations of `noise_integral` for different fmax values. I can include this in a next post or open a separate issue if you like.

Finally, I also considered your suggestion to pad the windows to the same length for all records. However, that is not so easy to do as it requires knowing the available lengths beforehand. I'm not sure this is really necessary, because there is already the `spectral_win_length` configuration parameter, which can be set to ensure padding/trimming of all windows to the same length.

I tested this variable window length for a case where I only have long-distance records (> 400 km). Using different fixed window lengths, the magnitude starts stabilizing for window lengths between 40 and 50 s, which more or less corresponds to using a `variable_win_length_factor` of 0.4 (for the S wave). Obviously, this would be much too long if I would include short-distance records and use a fixed window length.

Can you have a look at these modifications and let me know what you think?

Kris