### PR TITLE
New Spectrum() and SpectrumStream() classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@ previous versions. You will need to upgrade your old database manually or using
 - New HDF5 and TEXT file formats to store spectra
 - Station residuals are now saved in an HDF5 spectrum file, instead of a
   pickle file
+- New config file option `save_spectra` to save the spectra to an HDF5 file
+  in the output directory
 - Changes in the YAML output file:
   - `bsd` (Brune stress drop) parameter renamed to `ssd` (static stress drop)
   - Store in the `event_info` section the values of vp, vs and rho close to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,9 @@ previous versions. You will need to upgrade your old database manually or using
 - Introducing a new file format for providing event information
   (hypocentral location, magnitude, focal mechanism, moment tensor):
   the [SourceSpec Event File].
+- New HDF5 and TEXT file formats to store spectra
+- Station residuals are now saved in an HDF5 spectrum file, instead of a
+  pickle file
 - Changes in the YAML output file:
   - `bsd` (Brune stress drop) parameter renamed to `ssd` (static stress drop)
   - Store in the `event_info` section the values of vp, vs and rho close to

--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ The SourceSpec main code, `source_spec` will produce the following output files
   for [reproducibility])
 - `EVID.ssp.conf`: the input config file (for [reproducibility])
 - `EVID.residuals.hdf5`: station residuals in [HDF5] format
+- `EVID.spectra.hdf5`: (optional) spectra in [HDF5] format
 - `EVID.ssp.h`: hypocenter file in [HYPO71] format with the estimated moment
   magnitude (only if an input HYPO71 file is provided)
 - `EVID.xml`: updated [QuakeML] file with the results of the SourceSpec

--- a/README.md
+++ b/README.md
@@ -193,8 +193,7 @@ The SourceSpec main code, `source_spec` will produce the following output files
 - `EVID.ssp.log`: log file in text format (including the command line arguments,
   for [reproducibility])
 - `EVID.ssp.conf`: the input config file (for [reproducibility])
-- `EVID-residuals.pickle`: station residuals in
-  [Python pickle format][pickle]
+- `EVID.residuals.hdf5`: station residuals in [HDF5] format
 - `EVID.ssp.h`: hypocenter file in [HYPO71] format with the estimated moment
   magnitude (only if an input HYPO71 file is provided)
 - `EVID.xml`: updated [QuakeML] file with the results of the SourceSpec
@@ -483,7 +482,7 @@ please let me know.
 [Dataless SEED]: https://ds.iris.edu/ds/nodes/dmc/data/formats/dataless-seed/
 [SEED resp]: https://ds.iris.edu/ds/nodes/dmc/data/formats/resp/
 [SAC polezero (PAZ)]: https://www.jakewalter.net/sacresponse.html
-[pickle]: https://docs.python.org/3/library/pickle.html
+[HDF5]: https://en.wikipedia.org/wiki/Hierarchical_Data_Format
 [Cartopy]: https://scitools.org.uk/cartopy/docs/latest
 [SQLite]: https://www.sqlite.org
 [YAML]: https://yaml.org

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,8 @@ autodoc_mock_imports = [
     'lxml',
     'PIL',
     'shapely',
-    'tzlocal'
+    'tzlocal',
+    'h5py'
 ]
 napoleon_use_param = True
 napoleon_preprocess_types = True
@@ -75,7 +76,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'SourceSpec'
-copyright = '2013-2023, Claudio Satriano'  # pylint: disable=redefined-builtin
+copyright = '2013-2024, Claudio Satriano'  # pylint: disable=redefined-builtin
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/docs/file_formats.rst
+++ b/docs/file_formats.rst
@@ -90,7 +90,7 @@ output files (``EVID`` is replaced by the actual event ID):
 -  ``EVID.ssp.log``: log file in text format (including the command line
    arguments, for `reproducibility`_)
 -  ``EVID.ssp.conf``: the input config file (for `reproducibility`_)
--  ``EVID-residuals.pickle``: station residuals in Python `pickle`_ format
+-  ``EVID.residuals.hdf5``: station residuals in `HDF5`_ format
 -  ``EVID.ssp.h``: hypocenter file in `HYPO71`_ format with the estimated
    moment magnitude (only if an input HYPO71 file is provided)
 -  ``EVID.xml``: updated `QuakeML`_ file with the results of the SourceSpec
@@ -131,7 +131,7 @@ HTML format.
 .. _Dataless SEED: https://ds.iris.edu/ds/nodes/dmc/data/formats/dataless-seed/
 .. _SEED resp: https://ds.iris.edu/ds/nodes/dmc/data/formats/resp/
 .. _SAC polezero (PAZ): https://www.jakewalter.net/sacresponse.html
-.. _pickle: https://docs.python.org/3/library/pickle.html
+.. _HDF5: https://en.wikipedia.org/wiki/Hierarchical_Data_Format 
 .. _Cartopy: https://scitools.org.uk/cartopy/docs/latest
 .. _SQLite: https://www.sqlite.org
 .. _YAML: https://yaml.org

--- a/docs/file_formats.rst
+++ b/docs/file_formats.rst
@@ -91,6 +91,7 @@ output files (``EVID`` is replaced by the actual event ID):
    arguments, for `reproducibility`_)
 -  ``EVID.ssp.conf``: the input config file (for `reproducibility`_)
 -  ``EVID.residuals.hdf5``: station residuals in `HDF5`_ format
+-  ``EVID.spectra.hdf5``: (optional) spectra in `HDF5`_ format
 -  ``EVID.ssp.h``: hypocenter file in `HYPO71`_ format with the estimated
    moment magnitude (only if an input HYPO71 file is provided)
 -  ``EVID.xml``: updated `QuakeML`_ file with the results of the SourceSpec

--- a/docs/file_formats.rst
+++ b/docs/file_formats.rst
@@ -90,8 +90,10 @@ output files (``EVID`` is replaced by the actual event ID):
 -  ``EVID.ssp.log``: log file in text format (including the command line
    arguments, for `reproducibility`_)
 -  ``EVID.ssp.conf``: the input config file (for `reproducibility`_)
--  ``EVID.residuals.hdf5``: station residuals in `HDF5`_ format
--  ``EVID.spectra.hdf5``: (optional) spectra in `HDF5`_ format
+-  ``EVID.residuals.hdf5``: station residuals in
+   :ref:`spectral_file_formats:HDF5 File Format`
+-  ``EVID.spectra.hdf5``: (optional) spectra in
+   :ref:`spectral_file_formats:HDF5 File Format`
 -  ``EVID.ssp.h``: hypocenter file in `HYPO71`_ format with the estimated
    moment magnitude (only if an input HYPO71 file is provided)
 -  ``EVID.xml``: updated `QuakeML`_ file with the results of the SourceSpec
@@ -132,7 +134,6 @@ HTML format.
 .. _Dataless SEED: https://ds.iris.edu/ds/nodes/dmc/data/formats/dataless-seed/
 .. _SEED resp: https://ds.iris.edu/ds/nodes/dmc/data/formats/resp/
 .. _SAC polezero (PAZ): https://www.jakewalter.net/sacresponse.html
-.. _HDF5: https://en.wikipedia.org/wiki/Hierarchical_Data_Format 
 .. _Cartopy: https://scitools.org.uk/cartopy/docs/latest
 .. _SQLite: https://www.sqlite.org
 .. _YAML: https://yaml.org

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -102,7 +102,6 @@ More details are in section :ref:`configuration_file:Configuration File`.
 .. _Dataless SEED: https://ds.iris.edu/ds/nodes/dmc/data/formats/dataless-seed/
 .. _SEED resp: https://ds.iris.edu/ds/nodes/dmc/data/formats/resp/
 .. _SAC polezero (PAZ): https://www.jakewalter.net/sacresponse.html
-.. _pickle: https://docs.python.org/3/library/pickle.html
 .. _Cartopy: https://scitools.org.uk/cartopy/docs/latest
 .. _SQLite: https://www.sqlite.org
 .. _YAML: https://yaml.org

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -55,6 +55,7 @@ Contents:
    configuration_file
    file_formats
    source_spec_event_file
+   spectral_file_formats
    installation
    sample_runs
    getting_help

--- a/docs/spectral_file_formats.rst
+++ b/docs/spectral_file_formats.rst
@@ -86,21 +86,27 @@ Here is an example of how to read an HDF5 file and save it to a text file:
 
 HDF5 File Format
 ----------------
-In the HDF5 file format, each :class:`spectrum.Spectrum` object is stored in
-a `group`_ named ``spectrum_NNNN``, where ``NNNN`` is the index of the spectrum
-in the original :class:`spectrum.SpectrumStream` object. For each group,
-metadata is stored in the `attributes`_ section, and data is stored into
-6 `datasets`_, as illustrated below:
+In the HDF5 file format, all the spectra are stored in a group named
+``spectra``. This will allow for storing additional data types in the future.
+Within the ``spectra`` group, each :class:`spectrum.Spectrum` object is stored
+in a `group`_ named ``spectrum_NNNNN_NET.STA.LOC.CHAN``, where ``NNNN`` is the
+index of the spectrum in the original :class:`spectrum.SpectrumStream` object.
+For each group, metadata is stored in the `attributes`_ section, and data is
+stored into 6 `datasets`_, as illustrated below:
 
 .. code-block:: none
 
-    spectrum_NNNN ──> attributes
-      ├── data
-      ├── data_logspaced
-      ├── data_mag
-      ├── data_mag_logspaced
-      ├── freq
-      └── freq_logspaced
+    HDF5 ──> attributes
+      └── spectra
+          ├── spectrum_NNNNN_NET.STA.LOC.CHAN ──> attributes
+          |   ├── data
+          |   ├── data_logspaced
+          |   ├── data_mag
+          |   ├── data_mag_logspaced
+          |   ├── freq
+          |   └── freq_logspaced
+          ├── spectrum_NNNNN_NET.STA.LOC.CHAN ──> attributes
+          ...
 
 The mandatory metadata fields are:
 
@@ -134,25 +140,27 @@ Example code for reading a SourceSpec HDF5 file using ``h5py``:
 
     >>> import h5py
     >>> fp = h5py.File('38471103.spectra.hdf5', 'r')
-    >>> print('\n'.join(fp.keys()))
-    spectrum_0000
-    spectrum_0001
-    spectrum_0002
-    spectrum_0003
+    >>> spectra = fp['spectra']
+    >>> print('\n'.join(spectra.keys()))
+    spectrum_00000_CI.CCA..HHE
+    spectrum_00001_CI.CCA..HHH
+    spectrum_00002_CI.CCA..HHN
+    spectrum_00003_CI.CCA..HHS
     ...
-    >>> print(fp['spectrum_0000'].attrs['network'])
+    >>> spec = spectra['spectrum_00000_CI.CCA..HHE']
+    >>> print(spec.attrs['network'])
     CI
-    >>> print(fp['spectrum_0000'].attrs['station'])
+    >>> print(spec.attrs['station'])
     CCA
-    >>> print(fp['spectrum_0000'].attrs['channel'])
-    HHN
-    >>> print(fp['spectrum_0000'].attrs['coords'])
+    >>> print(spec.attrs['channel'])
+    HHE
+    >>> print(spec.attrs['coords'])
     {'elevation': 0.959, 'latitude': 35.34149169921875, 'longitude': -116.87464141845703}
-    >>> print(fp['spectrum_0000']['freq'][...])
+    >>> print(spec['freq'][...])
     [ 0.1996008   0.3992016   0.5988024   0.79840319  0.99800399  1.19760479
       1.39720559  1.59680639  1.79640719  1.99600798  2.19560878  2.39520958
     ...
-    >>> print(fp['spectrum_0000']['data'][...])
+    >>> print(spec['data'][...])
     [2.49035173e+15 1.37636948e+15 1.44746675e+15 1.63566457e+15
      6.93049162e+14 1.01315194e+15 9.36761128e+14 8.00776096e+14
     ...

--- a/docs/spectral_file_formats.rst
+++ b/docs/spectral_file_formats.rst
@@ -1,0 +1,226 @@
+.. _spectral_file_formats:
+
+#####################
+Spectral File Formats
+#####################
+
+Spectra produced by SourceSpec can be optionally saved in a `HDF5`_ file
+named ``EVID.spectra.hdf5`` (where ``EVID`` is the event ID; see the
+``save_spectra`` option in :ref:`configuration_file:Configuration File`).
+
+Additionally, spectral residuals are always saved to a file named
+``EVID.residuals.hdf5``, and average residuals produced by ``source_residuals``
+are saved to a file named ``residual_mean.hdf5``.
+
+All these files use an `HDF5`_ based format, detailed in the following
+section. They can be read using the function :func:`spectrum.read_spectra`,
+which returns a :class:`spectrum.SpectrumStream` object, consisting of
+:class:`spectrum.Spectrum` objects.
+
+Example code:
+
+.. code-block:: python
+
+    >>> from sourcespec.spectrum import read_spectra
+    >>> specst = read_spectra('38471103.spectra.hdf5')
+    >>> print(specst)
+    SpectrumStream with 439 Spectrum objects:
+    CI.CCA..HHE | 200 samples, 0.2-39.9 Hz | 0.2 Hz sample interval | 59 samples logspaced, 0.20-41.70 Hz | 0.04 log10([Hz]) sample interval logspaced
+    CI.CCA..HHH | 200 samples, 0.2-39.9 Hz | 0.2 Hz sample interval | 59 samples logspaced, 0.20-41.70 Hz | 0.04 log10([Hz]) sample interval logspaced
+    CI.CCA..HHN | 200 samples, 0.2-39.9 Hz | 0.2 Hz sample interval | 59 samples logspaced, 0.20-41.70 Hz | 0.04 log10([Hz]) sample interval logspaced
+    CI.CCA..HHS | 200 samples, 0.2-39.9 Hz | 0.2 Hz sample interval | 59 samples logspaced, 0.20-41.70 Hz | 0.04 log10([Hz]) sample interval logspaced
+    CI.CCA..HHZ | 200 samples, 0.2-39.9 Hz | 0.2 Hz sample interval | 59 samples logspaced, 0.20-41.70 Hz | 0.04 log10([Hz]) sample interval logspaced
+    CI.CCA..HHh | 200 samples, 0.2-39.9 Hz | 0.2 Hz sample interval | 59 samples logspaced, 0.20-41.70 Hz | 0.04 log10([Hz]) sample interval logspaced
+    CI.CCA..HHs | 200 samples, 0.2-39.9 Hz | 0.2 Hz sample interval | 59 samples logspaced, 0.20-41.70 Hz | 0.04 log10([Hz]) sample interval logspaced
+    ...
+    >>> print(specst[0])
+    Spectrum CI.CCA..HHE | 200 samples, 0.2-39.9 Hz | 0.2 Hz sample interval | 59 samples logspaced, 0.20-41.70 Hz | 0.04 log10([Hz]) sample interval logspaced
+    >>> print(specst[0].stats)
+    {'delta': 0.1996007984031936,
+     'npts': 200,
+     'delta_logspaced': 0.040000000000000036,
+     'npts_logspaced': 59,
+     'station': 'CCA',
+     'network': 'CI',
+     'location': '',
+     'channel': 'HHE',
+     'azimuth': 198.9047069007039,
+     'coeff': 1282817000215832.2,
+     'coords': {'elevation': 0.71,
+     'latitude': 35.15251922607422,
+     'longitude': -118.01648712158203},
+     ...
+
+
+Additionally, :class:`spectrum.SpectrumStream` and :class:`spectrum.Spectrum`
+objects can be saved to a text file format, with one ``Spectrum`` per file.
+The details of this format are explained below.
+
+Here is an example of how to read an HDF5 file and save it to a text file:
+
+.. code-block:: python
+
+    >>> from sourcespec.spectrum import read_spectra
+    >>> specst = read_spectra('38471103.spectra.hdf5')
+    >>> specst.write('38471103.spectra.txt', format='TEXT')
+    >>> from os import listdir
+    >>> print('\n'.join(sorted(listdir('.'))))
+    ...
+    38471103.spectra_0000.txt
+    38471103.spectra_0001.txt
+    38471103.spectra_0002.txt
+    38471103.spectra_0003.txt
+    38471103.spectra_0004.txt
+    38471103.spectra_0005.txt
+    38471103.spectra_0006.txt
+    38471103.spectra_0007.txt
+    38471103.spectra_0008.txt
+    38471103.spectra_0009.txt
+    38471103.spectra_0010.txt
+    ...
+    >>> specst0 = read_spectra('38471103.spectra_0000.txt', format='TEXT')
+    >>> print(specst0)
+    SpectrumStream with 1 Spectrum objects:
+    CI.CCA..HHE | 200 samples, 0.2-39.9 Hz | 0.2 Hz sample interval | 59 samples logspaced, 0.20-41.70 Hz | 0.04 log10([Hz]) sample interval logspaced
+
+
+HDF5 File Format
+----------------
+In the HDF5 file format, each :class:`spectrum.Spectrum` object is stored in
+a `group`_ named ``spectrum_NNNN``, where ``NNNN`` is the index of the spectrum
+in the original :class:`spectrum.SpectrumStream` object. For each group,
+metadata is stored in the `attributes`_ section, and data is stored into
+6 `datasets`_, as illustrated below:
+
+.. code-block:: none
+
+    spectrum_NNNN ──> attributes
+      ├── data
+      ├── data_logspaced
+      ├── data_mag
+      ├── data_mag_logspaced
+      ├── freq
+      └── freq_logspaced
+
+The mandatory metadata fields are:
+
+- ``network``: the network code;
+- ``station``: the station code;
+- ``location``: the location code;
+- ``channel``: the channel code;
+- ``delta``: the sample interval for linearly spaced frequencies;
+- ``npts``: the number of samples for linearly spaced frequencies and data;
+- ``delta_logspaced``: the sample interval for logspaced frequencies (set to 1
+  if logspaced frequencies are not used);
+- ``npts_logspaced``: the number of samples for logspaced frequencies and data
+  (set to 0 if logspaced frequencies are not used).
+
+Other metadata fields might be present. Dictionary-like metadata fields are
+stored as `YAML`_ strings.
+
+The 6 datasets are:
+
+- ``data`` (mandatory): spectral amplitude;
+- ``data_logspaced`` (optional): spectral amplitude for logspaced frequencies;
+- ``data_mag`` (optional): spectral amplitude in magnitude units;
+- ``data_mag_logspaced`` (optional): spectral amplitude in magnitude units for
+  logspaced frequencies;
+- ``freq`` (mandatory): linearly spaced frequencies;
+- ``freq_logspaced`` (optional): logspaced frequencies.
+
+Example code for reading a SourceSpec HDF5 file using ``h5py``:
+
+.. code-block:: python
+
+    >>> import h5py
+    >>> fp = h5py.File('38471103.spectra.hdf5', 'r')
+    >>> print('\n'.join(fp.keys()))
+    spectrum_0000
+    spectrum_0001
+    spectrum_0002
+    spectrum_0003
+    ...
+    >>> print(fp['spectrum_0000'].attrs['network'])
+    CI
+    >>> print(fp['spectrum_0000'].attrs['station'])
+    CCA
+    >>> print(fp['spectrum_0000'].attrs['channel'])
+    HHN
+    >>> print(fp['spectrum_0000'].attrs['coords'])
+    {'elevation': 0.959, 'latitude': 35.34149169921875, 'longitude': -116.87464141845703}
+    >>> print(fp['spectrum_0000']['freq'][...])
+    [ 0.1996008   0.3992016   0.5988024   0.79840319  0.99800399  1.19760479
+      1.39720559  1.59680639  1.79640719  1.99600798  2.19560878  2.39520958
+    ...
+    >>> print(fp['spectrum_0000']['data'][...])
+    [2.49035173e+15 1.37636948e+15 1.44746675e+15 1.63566457e+15
+     6.93049162e+14 1.01315194e+15 9.36761128e+14 8.00776096e+14
+    ...
+
+TEXT File Format
+----------------
+The TEXT file format is not used internally by SourceSpec, but it can be useful
+to convert the HDF5 files to a more human-readable format (see above for an
+example on reading an HDF5 file and converting it to TEXT format).
+
+The format is structured as follows:
+
+- A header section in `YAML`_ format. The header is identified by the two
+  lines ``# %BEGIN STATS YAML`` and ``# %END STATS YAML``. Each line in the
+  header starts with a ``#`` character, which should be removed when
+  using a YAML parser.
+- One or two data sections, each with three columns: ``frequency (Hz)``,
+  ``data``, ``data_mag`` (if ``data_mag`` is not present, it is set to ``nan``):
+
+  - linearly spaced data, between ``# %BEGIN LINSPACED DATA`` and
+    ``# %END LINSPACED DATA``;
+  - (optional) logspaced data, between ``# %BEGIN LOGSPACED DATA`` and
+    ``# %END LOGSPACED DATA``.
+
+Here's an example TEXT file (with ellipses for brevity):
+
+.. code-block::
+
+    # %SOURCESPEC TEXT SPECTRUM FORMAT 1.0
+    # %BEGIN STATS YAML
+    # delta: 0.1996007984031936
+    # npts: 200
+    # delta_logspaced: 0.040000000000000036
+    # npts_logspaced: 59
+    # station: CCA
+    # network: CI
+    # location: ''
+    # channel: HHE
+    # azimuth: 198.9047069007039
+    # coeff: 1282817000215832.2
+    # coords:
+    #   elevation: 0.71
+    #   latitude: 35.15251922607422
+    #   longitude: -118.01648712158203
+    ...
+    # %END STATS YAML
+    # %BEGIN LINSPACED DATA
+    # frequency(Hz) data data_mag
+    0.199601 60680538429002.429688 3.122033
+    0.399202 111489590392894.000000 3.298156
+    0.598802 109341550136192.765625 3.292523
+    0.798403 46532921128263.000000 3.045174
+    0.998004 69772021841544.039062 3.162454
+    ...
+    # %END LINSPACED DATA
+    # %BEGIN LOGSPACED DATA
+    # frequency_logspaced(Hz) data_logspaced data_mag_logspaced
+    0.199601 60680538429002.437500 3.122033
+    0.218858 65978522113754.125000 3.146268
+    0.239973 71686845260565.812500 3.170293
+    0.263125 77968569379397.437500 3.194613
+    0.288511 84857989097347.140625 3.219128
+    ...
+    # %END LOGSPACED DATA
+
+
+.. _HDF5: https://www.hdfgroup.org/
+.. _group: https://docs.h5py.org/en/stable/high/group.html
+.. _attributes: https://docs.h5py.org/en/stable/high/attr.html
+.. _datasets: https://docs.h5py.org/en/stable/high/dataset.html
+.. _YAML: http://yaml.org/

--- a/setup.py
+++ b/setup.py
@@ -92,5 +92,7 @@ setup(
         'obspy>=1.2.0',
         'pyproj',
         'tzlocal',
-        'pyyaml']
+        'pyyaml',
+        'h5py'
+    ]
 )

--- a/setup.py
+++ b/setup.py
@@ -92,7 +92,7 @@ setup(
         'obspy>=1.2.0',
         'pyproj',
         'tzlocal',
-        'pyyaml',
+        'pyyaml>=5.1',
         'h5py'
     ]
 )

--- a/sourcespec/config_files/configspec.conf
+++ b/sourcespec/config_files/configspec.conf
@@ -187,8 +187,9 @@ spectral_win_length = float(min=1e-99, default=None)
 spectral_smooth_width_decades = float(min=1e-99, default=0.2)
 
 # Residuals file path
-# (a pickle file with the mean residuals per station,
-# used for station correction):
+# An HDF5 file with the mean residuals per station, used for station
+# correction. This file is generally created using the command
+# "source_residuals" on a previous SourceSpec run.
 residuals_filepath = string(default=None)
 
 # Remove the signal baseline after instrument correction and before filtering

--- a/sourcespec/config_files/configspec.conf
+++ b/sourcespec/config_files/configspec.conf
@@ -222,6 +222,9 @@ freq1_broadb  = float(min=0, default=0.5)
 freq2_broadb  = float(min=0, default=30.0)
 freq1_disp    = float(min=0, default=0.5)
 freq2_disp    = float(min=0, default=30.0)
+
+# Save the spectra to an HDF5 file in the output directory
+save_spectra = boolean(default=False)
 # -------- SPECTRUM PARAMETERS
 
 

--- a/sourcespec/source_model.py
+++ b/sourcespec/source_model.py
@@ -7,7 +7,7 @@ Direct spectral modelling.
     2013-2014 Claudio Satriano <satriano@ipgp.fr>,
               Agnes Chounet <chounet@ipgp.fr>
 
-    2015-2023 Claudio Satriano <satriano@ipgp.fr>
+    2015-2024 Claudio Satriano <satriano@ipgp.fr>
 :license:
     CeCILL Free Software License Agreement v2.1
     (http://www.cecill.info/licences.en.html)
@@ -37,10 +37,9 @@ def make_synth(config, spec_st, trace_spec=None):
         spec = Spectrum()
         if trace_spec:
             spec.stats = deepcopy(trace_spec.stats)
+            spec.freq = trace_spec.freq.copy()
         else:
-            spec.stats.begin = fmin
-            spec.stats.delta = fdelta
-            spec.stats.npts = int((fmax - fmin) / fdelta)
+            spec.freq = np.arange(fmin, fmax, fdelta)
 
         if math.isnan(Mo):
             Mo = mag_to_moment(mag)
@@ -53,7 +52,7 @@ def make_synth(config, spec_st, trace_spec=None):
         spec.stats.par = {
             'Mw': mag, 'fc': fc, 't_star': t_star, 'alpha': alpha}
 
-        freq = spec.get_freq()
+        freq = spec.freq
         freq_logspaced = trace_spec.freq_logspaced
         spec.freq_logspaced = freq_logspaced
         spec.data_mag = spectral_model(freq, mag, fc, t_star, alpha)
@@ -89,10 +88,10 @@ def main():
     }
     config = configure(
         options, progname='source_model', config_overrides=conf_overrides)
+    from sourcespec.spectrum import SpectrumStream
     from sourcespec.ssp_read_traces import read_traces
     from sourcespec.ssp_process_traces import process_traces
     from sourcespec.ssp_build_spectra import build_spectra
-    from obspy.core import Stream
 
     # We don't use weighting in source_model
     config.weighting = 'no_weight'
@@ -105,8 +104,8 @@ def main():
         if len(spec_st) == 0:
             ssp_exit()
         # We keep just horizontal component:
-        spec_st = Stream([x for x in spec_st.traces
-                          if x.stats.channel[-1] == 'H'])
+        spec_st = SpectrumStream(
+            [x for x in spec_st if x.stats.channel[-1] == 'H'])
 
         for trace_spec in spec_st:
             orientation = trace_spec.stats.channel[-1]
@@ -114,7 +113,7 @@ def main():
                 continue
             make_synth(config, spec_st, trace_spec)
     else:
-        spec_st = Stream()
+        spec_st = SpectrumStream()
         make_synth(config, spec_st)
 
     from sourcespec.ssp_plot_spectra import plot_spectra

--- a/sourcespec/source_model.py
+++ b/sourcespec/source_model.py
@@ -55,11 +55,16 @@ def make_synth(config, spec_st, trace_spec=None):
         freq = spec.freq
         freq_logspaced = trace_spec.freq_logspaced
         spec.freq_logspaced = freq_logspaced
-        spec.data_mag = spectral_model(freq, mag, fc, t_star, alpha)
-        spec.data = mag_to_moment(spec.data_mag)
-        spec.data_mag_logspaced = spectral_model(
+        # spec.data and spec.data_logspaced have to be set before
+        # spec.data_mag and spec.data_mag_logspaced, so that the Spectrum
+        # object can check for consistency
+        data_mag = spectral_model(freq, mag, fc, t_star, alpha)
+        spec.data = mag_to_moment(data_mag)
+        spec.data_mag = data_mag
+        data_mag_logspaced = spectral_model(
             freq_logspaced, mag, fc, t_star, alpha)
-        spec.data_logspaced = mag_to_moment(spec.data_mag_logspaced)
+        spec.data_logspaced = mag_to_moment(data_mag_logspaced)
+        spec.data_mag_logspaced = data_mag_logspaced
         spec_st.append(spec)
 
         if trace_spec:

--- a/sourcespec/source_residuals.py
+++ b/sourcespec/source_residuals.py
@@ -18,6 +18,7 @@ from collections import defaultdict
 from argparse import ArgumentParser
 import matplotlib
 import matplotlib.pyplot as plt
+from sourcespec._version import get_versions
 from sourcespec.spectrum import read_spectra
 from sourcespec.ssp_util import moment_to_mag, mag_to_moment
 from sourcespec.spectrum import SpectrumStream
@@ -131,7 +132,8 @@ def compute_mean_residuals(residual_dict, min_spectra=20):
                 norm_mean += norm
         spec_mean.data_mag /= norm_mean
         spec_mean.data = mag_to_moment(spec_mean.data_mag)
-
+        spec_mean.stats.software = 'SourceSpec'
+        spec_mean.stats.software_version = get_versions()['version']
         residual_mean.append(spec_mean)
     return residual_mean
 

--- a/sourcespec/source_spec.py
+++ b/sourcespec/source_spec.py
@@ -73,8 +73,9 @@ def main():
     compute_summary_statistics(config, sspec_output)
 
     # Save output
-    from sourcespec.ssp_output import write_output
+    from sourcespec.ssp_output import write_output, save_spectra
     write_output(config, sspec_output)
+    save_spectra(config, spec_st)
 
     # Save residuals
     from sourcespec.ssp_residuals import spectral_residuals

--- a/sourcespec/spectrum.py
+++ b/sourcespec/spectrum.py
@@ -138,6 +138,18 @@ class Spectrum():
     def __repr__(self):
         return f'Spectrum {self}'
 
+    def __gt__(self, other):
+        return self.id > other.id
+
+    def __lt__(self, other):
+        return self.id < other.id
+
+    def __ge__(self, other):
+        return self.id >= other.id
+
+    def __le__(self, other):
+        return self.id <= other.id
+
     @property
     def id(self):
         """Return the id of the spectrum."""
@@ -381,6 +393,10 @@ class SpectrumStream(list):
 
     def __repr__(self):
         return self.__str__()
+
+    def sort(self, reverse=False):
+        """Sort the SpectrumStream in place."""
+        super().sort(reverse=reverse)
 
     def append(self, spectrum):
         """Append a spectrum to the collection."""

--- a/sourcespec/spectrum.py
+++ b/sourcespec/spectrum.py
@@ -1,31 +1,34 @@
 # -*- coding: utf-8 -*-
 # SPDX-License-Identifier: CECILL-2.1
 """
-A Spectrum() class defined as a modification of the ObsPy class Trace().
-
-Provides the high-level function do_spectrum()
-and the low-level function do_fft().
+Define Spectrum and SpectrumStream classes,
+similar to ObsPy's Trace and Stream.
 
 :copyright:
-    2012-2023 Claudio Satriano <satriano@ipgp.fr>
+    2012-2024 Claudio Satriano <satriano@ipgp.fr>
 :license:
     CeCILL Free Software License Agreement v2.1
     (http://www.cecill.info/licences.en.html)
 """
-from copy import copy, deepcopy
+import copy
+import fnmatch
 import numpy as np
-from obspy.core import Trace
 
 
-def do_fft(signal, delta):
-    """Compute the complex Fourier transform of a signal."""
+def signal_fft(signal, delta):
+    """
+    Compute the complex Fourier transform of a signal.
+
+    :param signal: The signal to transform.
+    :param delta: The sampling interval.
+    :return: The Fourier transform and the frequency axis.
+    """
     npts = len(signal)
     # if npts is even, we make it odd
     # so that we do not have a negative frequency in the last point
     # (see numpy.fft.rfft doc)
     if not npts % 2:
         npts -= 1
-
     # note that fft has the dimensions of the signal multiplied by time (delta)
     fft = np.fft.rfft(signal, n=npts) * delta
     fftfreq = np.fft.fftfreq(len(signal), d=delta)
@@ -33,65 +36,315 @@ def do_fft(signal, delta):
     return fft, fftfreq
 
 
-def do_spectrum(trace):
-    """Compute the spectrum of an ObsPy Trace object."""
-    signal = trace.data
-    delta = trace.stats.delta
-    amp, _freq = do_fft(signal, delta)
+class AttributeDict(dict):
+    """A dictionary that allows attribute-style access."""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
 
-    tr = Spectrum()
-    # remove DC component (freq=0)
-    tr.data = abs(amp)[1:]
-    tr.stats.delta = 1. / (len(signal) * delta)
-    tr.stats.begin = tr.stats.delta  # the first frequency is not 0!
-    tr.stats.npts = len(tr.data)
-    # copy some relevant header field
-    tr.stats.station = trace.stats.station
-    tr.stats.network = trace.stats.network
-    tr.stats.location = trace.stats.location
-    tr.stats.channel = trace.stats.channel
-    return tr
+    def __getattr__(self, name):
+        return self[name]
+
+    def __setattr__(self, name, value):
+        self[name] = value
+
+    def __dir__(self):
+        return self.keys()
+
+    def __copy__(self):
+        new_dict = AttributeDict()
+        for key, value in self.items():
+            new_dict[key] = value
+        return new_dict
+
+    def __deepcopy__(self, memo):
+        new_dict = AttributeDict()
+        for key, value in self.items():
+            new_dict[key] = copy.copy(value)
+        return new_dict
 
 
-class Spectrum(Trace):
+class Spectrum():
     """
-    A class to handle spectra.
-    """
+    A class to handle amplitude spectra.
 
-    def get_freq(self):
+    :param obspy_trace: An ObsPy Trace object to compute the spectrum from.
+    """
+    def __init__(self, obspy_trace=None):
+        """
+        Initialize the Spectrum object.
+
+        :param obspy_trace: An ObsPy Trace object to compute the spectrum from.
+        """
+        self._data = np.array([], dtype=float)
+        self._data_logspaced = np.array([], dtype=float)
+        self._data_mag = np.array([], dtype=float)
+        self._data_mag_logspaced = np.array([], dtype=float)
+        self._freq = np.array([], dtype=float)
+        self._freq_logspaced = np.array([], dtype=float)
+        self.stats = AttributeDict()
+        self.stats.delta = 1.
+        self.stats.npts = 0
+        self.stats.delta_logspaced = 1.
+        self.stats.npts_logspaced = 0
+        self.stats.station = ''
+        self.stats.network = ''
+        self.stats.location = ''
+        self.stats.channel = ''
+        if obspy_trace is not None:
+            self.from_obspy_trace(obspy_trace)
+
+    @property
+    def id(self):
+        """Return the id of the spectrum."""
+        return (
+            f'{self.stats.network}.{self.stats.station}.'
+            f'{self.stats.location}.{self.stats.channel}'
+        )
+
+    @id.setter
+    def id(self, value):
+        """Set the id of the spectrum."""
+        try:
+            net, sta, loc, cha = value.split('.')
+        except ValueError as e:
+            raise ValueError(f'Not a valid SEED id: {value}') from e
+        self.stats.network = net
+        self.stats.station = sta
+        self.stats.location = loc
+        self.stats.channel = cha
+
+    def get_id(self):
+        """Return the id of the spectrum."""
+        return self.id
+
+    @property
+    def data(self):
+        """Return the array containing the amplitude spectrum."""
+        return self._data
+
+    @data.setter
+    def data(self, value):
+        """Set the array containing the amplitude spectrum."""
+        if not isinstance(value, np.ndarray):
+            value = np.array(value)
+        self._data = value
+        self.stats.npts = len(value)
+
+    @property
+    def data_mag(self):
+        """
+        Return the array containing the amplitude spectrum in mangitude units.
+        """
+        return self._data_mag
+
+    @data_mag.setter
+    def data_mag(self, value):
+        """
+        Set the array containing the amplitude spectrum in magnitude units.
+        """
+        if not isinstance(value, np.ndarray):
+            value = np.array(value)
+        if len(value) > 0 and len(value) != len(self.data):
+            raise ValueError('data_mag must have the same length as data')
+        self._data_mag = value
+
+    @property
+    def data_logspaced(self):
+        """
+        Return the array containing the amplitude spectrum in logspaced
+        frequencies.
+        """
+        return self._data_logspaced
+
+    @data_logspaced.setter
+    def data_logspaced(self, value):
+        """
+        Set the array containing the amplitude spectrum in logspaced
+        frequencies.
+        """
+        if not isinstance(value, np.ndarray):
+            value = np.array(value)
+        self._data_logspaced = value
+        self.stats.npts_logspaced = len(value)
+
+    @property
+    def data_mag_logspaced(self):
+        """
+        Return the array containing the amplitude spectrum in logspaced
+        frequencies in magnitude units.
+        """
+        return self._data_mag_logspaced
+
+    @data_mag_logspaced.setter
+    def data_mag_logspaced(self, value):
+        """
+        Set the array containing the amplitude spectrum in logspaced
+        frequencies in magnitude units.
+        """
+        if not isinstance(value, np.ndarray):
+            value = np.array(value)
+        if len(value) > 0 and len(value) != len(self.data_logspaced):
+            raise ValueError(
+                'data_mag_logspaced must have the same length as '
+                'data_logspaced'
+            )
+        self._data_mag_logspaced = value
+
+    @property
+    def freq(self):
         """Return the frequency axis of the spectrum."""
-        fdelta = self.stats.delta
-        freq = np.arange(0, self.stats.npts * fdelta, fdelta)
-        freq = freq[:self.stats.npts]
-        freq += self.stats.begin
-        return freq
+        return self._freq
+
+    @freq.setter
+    def freq(self, value):
+        """Set the frequency axis of the spectrum."""
+        if not isinstance(value, np.ndarray):
+            value = np.array(value)
+        if len(value) > 0:
+            delta = np.diff(value)
+            if not np.isclose(delta, delta[0], rtol=0.01).all():
+                raise ValueError('Frequency axis must be evenly spaced')
+            self.stats.delta = float(delta[0])
+        else:
+            self.stats.delta = 1.
+        self._freq = value
+
+    @property
+    def freq_logspaced(self):
+        """Return the logspaced frequency axis of the spectrum."""
+        return self._freq_logspaced
+
+    @freq_logspaced.setter
+    def freq_logspaced(self, value):
+        """Set the logspaced frequency axis of the spectrum."""
+        if not isinstance(value, np.ndarray):
+            value = np.array(value)
+        if len(value) > 0:
+            delta_logspaced = np.diff(np.log10(value))
+            if not np.isclose(
+                delta_logspaced, delta_logspaced[0], rtol=0.01
+            ).all():
+                raise ValueError(
+                    'Logspaced frequency axis must be evenly spaced')
+            self.stats.delta_logspaced = float(delta_logspaced[0])
+        else:
+            self.stats.delta_logspaced = 1.
+        self._freq_logspaced = value
+
+    def copy(self):
+        """Return a copy of the spectrum."""
+        spec_copy = Spectrum()
+        spec_copy.stats = AttributeDict(self.stats)
+        spec_copy.data = self.data.copy()
+        spec_copy.data_mag = self.data_mag.copy()
+        spec_copy.data_logspaced = self.data_logspaced.copy()
+        spec_copy.data_mag_logspaced = self.data_mag_logspaced.copy()
+        spec_copy.freq = self.freq.copy()
+        spec_copy.freq_logspaced = self.freq_logspaced.copy()
+        return spec_copy
+
+    def slice(self, fmin, fmax, nearest_sample=True, pad=False,
+              fill_value=None):
+        """
+        Slice the spectrum between fmin and fmax.
+
+        :param fmin: Minimum frequency.
+        :param fmax: Maximum frequency.
+        :param nearest_sample: If True, the slice will include the nearest
+            frequency to fmin and fmax.
+        :param pad: If True, the slice will be padded with the value of
+            fill_value until fmin and fmax are included.
+        :param fill_value: The value to use for padding.
+
+        :note: Only the linear spaced frequencies, data and data_mag are
+            sliced. If the original spectrum contains logspaced frequencies,
+            data, and data_mag, those are not preserved in the sliced spectrum.
+        """
+        freq = self.freq
+        slice_condition = (freq >= fmin) & (freq <= fmax)
+        if nearest_sample:
+            # find the closest frequency to fmin:
+            idx = (np.abs(freq - fmin)).argmin()
+            slice_condition[idx] = True
+            # find the closest frequency to fmax:
+            idx = (np.abs(freq - fmax)).argmin()
+            slice_condition[idx] = True
+        freqs_slice = freq[slice_condition]
+        data_slice = self.data[slice_condition]
+        data_mag_slice =\
+            self.data_mag[slice_condition] if self.data_mag.size\
+            else np.array([])
+        if pad:
+            # add values to the slice until fmin and fmax are included
+            while freqs_slice[0] > fmin:
+                freqs_slice = np.insert(
+                    freqs_slice, 0, freqs_slice[0] - self.stats.delta)
+                data_slice = np.insert(data_slice, 0, fill_value)
+                if data_mag_slice.size:
+                    data_mag_slice = np.insert(data_mag_slice, 0, fill_value)
+            while freqs_slice[-1] < fmax:
+                freqs_slice = np.append(
+                    freqs_slice, freqs_slice[-1] + self.stats.delta)
+                data_slice = np.append(data_slice, fill_value)
+                if data_mag_slice.size:
+                    data_mag_slice = np.append(data_mag_slice, fill_value)
+        spec_slice = Spectrum()
+        spec_slice.stats = AttributeDict(self.stats)
+        spec_slice.data = data_slice
+        spec_slice.data_mag = data_mag_slice
+        spec_slice.freq = freqs_slice
+        return spec_slice
 
     def plot(self, **kwargs):
-        """Plot the spectrum."""
+        """Plot the amplitude spectrum."""
         # pylint: disable=import-outside-toplevel
-        freq = self.get_freq()
         import matplotlib.pyplot as plt
-        plt.loglog(freq, self.data, **kwargs)
+        plt.loglog(self.freq, self.data, **kwargs)
         plt.grid(True)
         plt.xlabel('Frequency (Hz)')
         plt.ylabel('Amplitude')
         plt.show()
 
-    def slice(self, fmin, fmax, pad=False, nearest_sample=True,
-              fill_value=None):
-        t = self.stats.starttime
-        freq = self.get_freq()
-        begin = self.stats.begin
-        spec_slice = copy(self)
-        spec_slice.stats = deepcopy(self.stats)
-        spec_slice.trim(
-            t - begin + fmin, t - begin + fmax,
-            pad, nearest_sample, fill_value)
-        delta_t = t - spec_slice.stats.starttime
-        if delta_t > 0:
-            spec_slice.stats.begin = begin - delta_t
-        else:
-            # find the closest frequency to fmin:
-            idx = (np.abs(spec_slice.get_freq() - fmin)).argmin()
-            spec_slice.stats.begin = freq[idx]
-        return spec_slice
+    def from_obspy_trace(self, trace):
+        """Compute the spectrum from an ObsPy Trace object."""
+        # pylint: disable=import-outside-toplevel
+        from obspy.core.trace import Trace
+        if not isinstance(trace, Trace):
+            raise TypeError('Only ObsPy Trace objects are supported')
+        signal = trace.data
+        delta = trace.stats.delta
+        amp, freq = signal_fft(signal, delta)
+        # remove DC component (freq=0)
+        self.data = np.abs(amp)[1:]
+        self.freq = freq[1:]
+        # copy the trace metadata
+        self.stats.station = trace.stats.station
+        self.stats.network = trace.stats.network
+        self.stats.location = trace.stats.location
+        self.stats.channel = trace.stats.channel
+
+
+class SpectrumStream(list):
+    """
+    A class to handle a collection of amplitude spectra.
+    """
+    def append(self, spectrum):
+        """Append a spectrum to the collection."""
+        if not isinstance(spectrum, Spectrum):
+            raise TypeError('Only Spectrum objects can be appended')
+        super().append(spectrum)
+
+    def select(self, **kwargs):
+        """Select a subset of the SpectrumStream."""
+        selected = SpectrumStream()
+        for spectrum in self:
+            for key, value in kwargs.items():
+                if key == 'id':
+                    stored_value = spectrum.get_id()
+                else:
+                    stored_value = getattr(spectrum.stats, key)
+                if not fnmatch.fnmatch(stored_value, value):
+                    break
+            else:
+                selected.append(spectrum)
+        return selected

--- a/sourcespec/spectrum.py
+++ b/sourcespec/spectrum.py
@@ -601,11 +601,24 @@ def _quoted_representer(dumper, data):
     return dumper.represent_scalar('tag:yaml.org,2002:str', data, style="'")
 
 
+def _dict_constructor(loader, node):
+    """
+    YAML constructor for dictionaries.
+
+    :param loader: The YAML loader.
+    :param node: The node to construct.
+    :return: The dictionary constructed from the node.
+    """
+    return AttributeDict(loader.construct_mapping(node))
+
+
 # register the representers
 yaml.representer.SafeRepresenter.add_representer(
     None, _default_yaml_representer)
 _HDF5HeaderDumper.add_representer(str, _quoted_representer)
 _HDF5HeaderDumper.add_representer(None, _default_yaml_representer)
+# register the constructor
+yaml.SafeLoader.add_constructor('tag:yaml.org,2002:map', _dict_constructor)
 
 
 def _normalize_metadata_object(obj):

--- a/sourcespec/spectrum.py
+++ b/sourcespec/spectrum.py
@@ -51,7 +51,13 @@ class AttributeDict(dict):
         super().__init__(*args, **kwargs)
 
     def __getattr__(self, name):
-        return self[name]
+        try:
+            return self.__getitem__(name)
+        except KeyError as e:
+            raise AttributeError(
+                f"'{self.__class__.__name__}' object has no attribute "
+                f"'{name}'"
+            ) from e
 
     def __setattr__(self, name, value):
         self[name] = value

--- a/sourcespec/spectrum.py
+++ b/sourcespec/spectrum.py
@@ -618,7 +618,7 @@ def _normalize_metadata_object(obj):
     All the other types are left unchanged.
 
     :param obj: The object to normalize.
-    :return: A dictionary or the original value.
+    :return: A dictionary, a float, or the original value.
     """
     if hasattr(obj, 'items'):
         return {

--- a/sourcespec/ssp_correction.py
+++ b/sourcespec/ssp_correction.py
@@ -12,9 +12,9 @@ Spectral station correction calculated from ssp_residuals.
     CeCILL Free Software License Agreement v2.1
     (http://www.cecill.info/licences.en.html)
 """
-import pickle
 import logging
 from scipy.interpolate import interp1d
+from sourcespec.spectrum import read_spectra
 from sourcespec.ssp_util import moment_to_mag, mag_to_moment
 from sourcespec.ssp_setup import ssp_exit
 logger = logging.getLogger(__name__.rsplit('.', maxsplit=1)[-1])
@@ -30,8 +30,7 @@ def station_correction(spec_st, config):
     if res_filepath is None:
         return spec_st
     try:
-        with open(res_filepath, 'rb') as fp:
-            residual = pickle.load(fp)
+        residual = read_spectra(res_filepath)
     except Exception as msg:
         logger.error(msg)
         ssp_exit(1)

--- a/sourcespec/ssp_correction.py
+++ b/sourcespec/ssp_correction.py
@@ -7,7 +7,7 @@ Spectral station correction calculated from ssp_residuals.
     2013-2014 Claudio Satriano <satriano@ipgp.fr>,
               Agnes Chounet <chounet@ipgp.fr>
 
-    2015-2023 Claudio Satriano <satriano@ipgp.fr>
+    2015-2024 Claudio Satriano <satriano@ipgp.fr>
 :license:
     CeCILL Free Software License Agreement v2.1
     (http://www.cecill.info/licences.en.html)
@@ -42,7 +42,7 @@ def station_correction(spec_st, config):
             corr = residual.select(id=spec.id)[0]
         except IndexError:
             continue
-        freq = spec.get_freq()
+        freq = spec.freq
         fmin = freq.min()
         fmax = freq.max()
         corr = corr.slice(fmin, fmax)

--- a/sourcespec/ssp_event.py
+++ b/sourcespec/ssp_event.py
@@ -46,7 +46,34 @@ def _dyne_cm_to_N_m(value):
     return None if value is None else value * 1e-7
 
 
-class SSPCoordinate():
+class _SSPEventBaseClass():
+    """
+    SourceSpec event base class.
+    """
+    # make the class subscriptable
+    def __getitem__(self, key):
+        return getattr(self, key)
+
+    def keys(self):
+        """
+        Return the event attribute names as a list.
+        """
+        return self.__dict__.keys()
+
+    def values(self):
+        """
+        Return the event attributes as a list.
+        """
+        return self.__dict__.values()
+
+    def items(self):
+        """
+        Return the event attributes as a list of tuples.
+        """
+        return self.__dict__.items()
+
+
+class SSPCoordinate(_SSPEventBaseClass):
     """
     SourceSpec coordinate class.
 
@@ -63,10 +90,6 @@ class SSPCoordinate():
         else:
             raise ValueError('coordinate units must be deg')
 
-    # make the class subscriptable
-    def __getitem__(self, key):
-        return getattr(self, key)
-
     def __str__(self):
         try:
             return f'{self.value_in_deg:.4f}°'
@@ -74,7 +97,7 @@ class SSPCoordinate():
             raise TypeError('Incomplete coordinate data') from e
 
 
-class SSPDepth():
+class SSPDepth(_SSPEventBaseClass):
     """
     SourceSpec depth class.
     """
@@ -83,10 +106,6 @@ class SSPDepth():
             warnings.warn(f'Ignoring unknown depth field "{key}"')
         self.value = _float(value)
         self.units = units
-
-    # make the class subscriptable
-    def __getitem__(self, key):
-        return getattr(self, key)
 
     def __str__(self):
         try:
@@ -117,7 +136,7 @@ class SSPDepth():
         raise ValueError('depth units must be m or km')
 
 
-class SSPHypocenter():
+class SSPHypocenter(_SSPEventBaseClass):
     """
     SourceSpec hypocenter class.
     """
@@ -139,10 +158,6 @@ class SSPHypocenter():
         self.depth = SSPDepth(**depth)
         self.origin_time = _time(origin_time)
 
-    # make the class subscriptable
-    def __getitem__(self, key):
-        return getattr(self, key)
-
     def __str__(self):
         try:
             return (
@@ -155,7 +170,7 @@ class SSPHypocenter():
             raise TypeError('Incomplete hypocenter data') from e
 
 
-class SSPMagnitude():
+class SSPMagnitude(_SSPEventBaseClass):
     """
     SourceSpec magnitude class.
     """
@@ -165,10 +180,6 @@ class SSPMagnitude():
         self.value = _float(value)
         self.mag_type = mag_type
         self.computed = False
-
-    # make the class subscriptable
-    def __getitem__(self, key):
-        return getattr(self, key)
 
     def __str__(self):
         try:
@@ -198,7 +209,7 @@ class SSPMagnitude():
         self.computed = True
 
 
-class SSPScalarMoment():
+class SSPScalarMoment(_SSPEventBaseClass):
     """
     SourceSpec scalar moment class.
     """
@@ -208,10 +219,6 @@ class SSPScalarMoment():
         self.value = _float(value)
         self.units = units
         self.to_N_m()
-
-    # make the class subscriptable
-    def __getitem__(self, key):
-        return getattr(self, key)
 
     def __str__(self):
         try:
@@ -247,7 +254,7 @@ class SSPScalarMoment():
         self.to_N_m()
 
 
-class SSPFocalMechanism():
+class SSPFocalMechanism(_SSPEventBaseClass):
     """
     SourceSpec focal mechanism class.
 
@@ -260,10 +267,6 @@ class SSPFocalMechanism():
         self.dip = _float(dip)
         self.rake = _float(rake)
         self.units = units  # currently not used
-
-    # make the class subscriptable
-    def __getitem__(self, key):
-        return getattr(self, key)
 
     def __str__(self):
         try:
@@ -290,7 +293,7 @@ class SSPFocalMechanism():
         self.strike, self.dip, self.rake = _fps1
 
 
-class SSPMomentTensor():
+class SSPMomentTensor(_SSPEventBaseClass):
     """
     SourceSpec moment tensor class.
     """
@@ -306,10 +309,6 @@ class SSPMomentTensor():
         self.m_rp = _float(m_rp)
         self.m_tp = _float(m_tp)
         self.to_N_m()
-
-    # make the class subscriptable
-    def __getitem__(self, key):
-        return getattr(self, key)
 
     def __str__(self):
         try:
@@ -338,7 +337,7 @@ class SSPMomentTensor():
             self.units = 'N-m'
 
 
-class SSPEvent():
+class SSPEvent(_SSPEventBaseClass):
     """
     SourceSpec event class.
     """
@@ -358,10 +357,6 @@ class SSPEvent():
         self.moment_tensor = SSPMomentTensor()
         if event_dict is not None:
             self.from_event_dict(event_dict)
-
-    # make the class subscriptable
-    def __getitem__(self, key):
-        return getattr(self, key)
 
     def __str__(self):
         outstr = ''

--- a/sourcespec/ssp_inversion.py
+++ b/sourcespec/ssp_inversion.py
@@ -10,7 +10,7 @@ Spectral inversion routines for sourcespec.
               Emanuela Matrullo <matrullo@geologie.ens.fr>,
               Agnes Chounet <chounet@ipgp.fr>
 
-    2015-2023 Claudio Satriano <satriano@ipgp.fr>
+    2015-2024 Claudio Satriano <satriano@ipgp.fr>
 :license:
     CeCILL Free Software License Agreement v2.1
     (http://www.cecill.info/licences.en.html)
@@ -19,8 +19,8 @@ import logging
 import numpy as np
 from scipy.optimize import curve_fit, minimize, basinhopping
 from scipy.signal import argrelmax
-from obspy import Stream
 from obspy.geodetics import gps2dist_azimuth
+from sourcespec.spectrum import SpectrumStream
 from sourcespec.ssp_spectral_model import (
     spectral_model, objective_func, callback)
 from sourcespec.ssp_util import (
@@ -397,12 +397,11 @@ def _synth_spec(config, spec, station_pars):
         x.param_id: x.compact_uncertainty()
         for x in station_pars.get_spectral_parameters().values()
     }
-    spec_st = Stream()
     params_opt = [par[key] for key in ('Mw', 'fc', 't_star')]
-
     chan_no_orientation = spec.stats.channel[:-1]
+    spec_st = SpectrumStream()
 
-    freq = spec.get_freq()
+    freq = spec.freq
     freq_logspaced = spec.freq_logspaced
     spec_synth = spec.copy()
     spec_synth.stats.channel = f'{chan_no_orientation}S'

--- a/sourcespec/ssp_output.py
+++ b/sourcespec/ssp_output.py
@@ -445,5 +445,8 @@ def save_spectra(config, spec_st):
         f'{config.event.event_id}.spectra.hdf5'
     )
     spec_st.sort()
+    for spec in spec_st:
+        spec.stats.software = 'SourceSpec'
+        spec.stats.software_version = get_versions()['version']
     spec_st.write(outfile)
     logger.info(f'Spectra saved to: {outfile}')

--- a/sourcespec/ssp_output.py
+++ b/sourcespec/ssp_output.py
@@ -434,3 +434,16 @@ def write_output(config, sspec_output):
     _write_hypo71(config, sspec_output)
     # Write to quakeml file, if requested
     write_qml(config, sspec_output)
+
+
+def save_spectra(config, spec_st):
+    """Save spectra to file."""
+    if not config.save_spectra:
+        return
+    outfile = os.path.join(
+        config.options.outdir,
+        f'{config.event.event_id}.spectra.hdf5'
+    )
+    spec_st.sort()
+    spec_st.write(outfile)
+    logger.info(f'Spectra saved to: {outfile}')

--- a/sourcespec/ssp_plot_spectra.py
+++ b/sourcespec/ssp_plot_spectra.py
@@ -9,7 +9,7 @@ Spectral plotting routine.
     2013-2014 Claudio Satriano <satriano@ipgp.fr>,
               Emanuela Matrullo <matrullo@geologie.ens.fr>
 
-    2015-2023 Claudio Satriano <satriano@ipgp.fr>
+    2015-2024 Claudio Satriano <satriano@ipgp.fr>
 :license:
     CeCILL Free Software License Agreement v2.1
     (http://www.cecill.info/licences.en.html)
@@ -84,7 +84,7 @@ class PlotParams():
                     spec_st_sel += specnoise_sel
             for spec in spec_st_sel:
                 moment_minmax, freq_minmax = spec_minmax(
-                    spec.data, spec.get_freq(), moment_minmax, freq_minmax)
+                    spec.data, spec.freq, moment_minmax, freq_minmax)
             # increment the number of plots,
             # based on the number of uniqs band+instrument codes
             nplots += len({x.stats.channel[:-1] for x in spec_st_sel})
@@ -600,14 +600,13 @@ def _plot_spec(config, plot_params, spec, spec_noise):
             _plot_fc_and_mw(spec, ax, ax2)
     elif plot_type == 'weight':
         ax.semilogx(
-            spec.get_freq(), spec.data, color=color, alpha=alpha,
-            zorder=20)
+            spec.freq, spec.data, color=color, alpha=alpha, zorder=20)
     else:
         raise ValueError(f'Unknown plot type: {plot_type}')
 
     if spec_noise:
         ax.loglog(
-            spec_noise.get_freq(), spec_noise.data,
+            spec_noise.freq, spec_noise.data,
             linestyle=':', linewidth=linewidth,
             color=color, alpha=alpha, zorder=20)
     if orientation == 'S':

--- a/sourcespec/ssp_plot_stacked_spectra.py
+++ b/sourcespec/ssp_plot_stacked_spectra.py
@@ -4,7 +4,7 @@
 Plot stacked spectra, along with summary inverted spectrum.
 
 :copyright:
-    2023 Claudio Satriano <satriano@ipgp.fr>
+    2023-2024 Claudio Satriano <satriano@ipgp.fr>
 :license:
     CeCILL Free Software License Agreement v2.1
     (http://www.cecill.info/licences.en.html)
@@ -222,7 +222,7 @@ def plot_stacked_spectra(config, spec_st, sspec_output):
     fmins = []
     fmaxs = []
     for spec in selected_specs:
-        freqs = spec.get_freq()
+        freqs = spec.freq
         spec_handle, = ax.loglog(
             freqs, spec.data, color=color, lw=linewidth,
             alpha=alpha, zorder=20)

--- a/sourcespec/ssp_radiated_energy.py
+++ b/sourcespec/ssp_radiated_energy.py
@@ -10,7 +10,7 @@ Compute radiated energy from spectral integration.
               Emanuela Matrullo <matrullo@geologie.ens.fr>,
               Agnes Chounet <chounet@ipgp.fr>
 
-    2015-2023 Claudio Satriano <satriano@ipgp.fr>
+    2015-2024 Claudio Satriano <satriano@ipgp.fr>
 :license:
     CeCILL Free Software License Agreement v2.1
     (http://www.cecill.info/licences.en.html)
@@ -28,7 +28,7 @@ def _spectral_integral(spec, t_star, fmin=None, fmax=None):
     # eq. (1) in Boatwright et al. (2002), but expressed in frequency,
     # instead of angular frequency (2pi factor).
     deltaf = spec.stats.delta
-    freq = spec.get_freq()
+    freq = spec.freq
     # Data is in moment units. By dividing by coeff, we get the units of the
     # Fourier transform of the ground displacement (m * s) multiplied by the
     # units of the geometrical spreading correction (m).
@@ -118,7 +118,7 @@ def _finite_bandwidth_correction(spec, fc, fmax):
     - Lancieri et al. (2012), eq. 4 (note, missing parenthesis in the paper)
     """
     if fmax is None:
-        fmax = spec.get_freq()[-1]
+        fmax = spec.freq[-1]
     return (
         2. / np.pi *
         (np.arctan2(fmax, fc) - (fmax / fc) / (1 + (fmax / fc)**2.))
@@ -144,9 +144,9 @@ def _get_frequency_range(config, spec):
             'Using the whole frequency range.')
         fmin, fmax = None, None
     if fmin is None:
-        fmin = spec.get_freq()[0]
+        fmin = spec.freq[0]
     if fmax is None:
-        fmax = spec.get_freq()[-1]
+        fmax = spec.freq[-1]
     logger.info(
         f'{spec.id} {spec.stats.instrtype}: frequency range for '
         f'spectral integration: {fmin:.1f}-{fmax:.1f} Hz')

--- a/sourcespec/ssp_read_traces.py
+++ b/sourcespec/ssp_read_traces.py
@@ -171,9 +171,14 @@ def _add_coords(trace):
         raise RuntimeError()
     coords = None
     with contextlib.suppress(Exception):
-        coords = AttribDict(
-            trace.stats.inventory.get_coordinates(
-                trace.id, trace.stats.starttime))
+        # Inventory.get_coordinates() raises a generic Exception
+        # if coordinates are not found
+        coords = trace.stats.inventory.get_coordinates(
+                    trace.id, trace.stats.starttime)
+    if coords is not None:
+        # Build an AttribDict and make sure that coordinates are floats
+        coords = AttribDict({
+            key: float(value) for key, value in coords.items()})
         coords = (
             None if (
                 coords.longitude == 0 and coords.latitude == 0 and

--- a/sourcespec/ssp_residuals.py
+++ b/sourcespec/ssp_residuals.py
@@ -14,6 +14,7 @@ Spectral residual routine for sourcespec.
 """
 import os
 import logging
+from sourcespec._version import get_versions
 from sourcespec.spectrum import SpectrumStream
 from sourcespec.ssp_spectral_model import spectral_model
 from sourcespec.ssp_util import mag_to_moment
@@ -47,6 +48,8 @@ def spectral_residuals(config, spec_st, sspec_output):
             res = spec.copy()
             res.data_mag = spec.data_mag - synth_mean_mag
             res.data = mag_to_moment(res.data_mag)
+            res.stats.software = 'SourceSpec'
+            res.stats.software_version = get_versions()['version']
             residuals.append(res)
     # Save residuals to HDF5 file
     evid = config.event.event_id

--- a/sourcespec/ssp_residuals.py
+++ b/sourcespec/ssp_residuals.py
@@ -14,7 +14,6 @@ Spectral residual routine for sourcespec.
 """
 import os
 import logging
-import pickle
 from sourcespec.spectrum import SpectrumStream
 from sourcespec.ssp_spectral_model import spectral_model
 from sourcespec.ssp_util import mag_to_moment
@@ -24,8 +23,14 @@ logger = logging.getLogger(__name__.rsplit('.', maxsplit=1)[-1])
 def spectral_residuals(config, spec_st, sspec_output):
     """
     Compute spectral residuals with respect to an average spectral model.
+    Saves a stream of residuals to disk in HDF5 format.
 
-    Saves a stream of residuals to disk using pickle.
+    :param config: Configuration object
+    :type config: :class:`~sourcespec.config.Config`
+    :param spec_st: Stream of spectra
+    :type spec_st: :class:`~sourcespec.spectrum.SpectrumStream`
+    :param sspec_output: Output of the source spectral parameter estimation
+    :type sspec_output: :class:`~sourcespec.ssp_data_types.SourceSpecOutput`
     """
     # get reference summary values
     summary_values = sspec_output.reference_values()
@@ -37,18 +42,14 @@ def spectral_residuals(config, spec_st, sspec_output):
         for spec in spec_st_sel:
             if spec.stats.channel[-1] != 'H':
                 continue
-
             xdata = spec.freq
             synth_mean_mag = spectral_model(xdata, **sourcepar_summary)
-
             res = spec.copy()
             res.data_mag = spec.data_mag - synth_mean_mag
             res.data = mag_to_moment(res.data_mag)
             residuals.append(res)
-
-    # Save residuals as pickle file
+    # Save residuals to HDF5 file
     evid = config.event.event_id
-    res_file = os.path.join(config.options.outdir, f'{evid}-residuals.pickle')
-    with open(res_file, 'wb') as fp:
-        pickle.dump(residuals, fp)
+    res_file = os.path.join(config.options.outdir, f'{evid}.residuals.hdf5')
+    residuals.write(res_file, format='HDF5')
     logger.info(f'Spectral residuals saved to: {res_file}')

--- a/sourcespec/ssp_residuals.py
+++ b/sourcespec/ssp_residuals.py
@@ -7,7 +7,7 @@ Spectral residual routine for sourcespec.
     2013-2014 Claudio Satriano <satriano@ipgp.fr>,
               Agnes Chounet <chounet@ipgp.fr>
 
-    2015-2023 Claudio Satriano <satriano@ipgp.fr>
+    2015-2024 Claudio Satriano <satriano@ipgp.fr>
 :license:
     CeCILL Free Software License Agreement v2.1
     (http://www.cecill.info/licences.en.html)
@@ -15,7 +15,7 @@ Spectral residual routine for sourcespec.
 import os
 import logging
 import pickle
-from obspy.core import Stream
+from sourcespec.spectrum import SpectrumStream
 from sourcespec.ssp_spectral_model import spectral_model
 from sourcespec.ssp_util import mag_to_moment
 logger = logging.getLogger(__name__.rsplit('.', maxsplit=1)[-1])
@@ -31,14 +31,14 @@ def spectral_residuals(config, spec_st, sspec_output):
     summary_values = sspec_output.reference_values()
     params_name = ('Mw', 'fc', 't_star')
     sourcepar_summary = {p: summary_values[p] for p in params_name}
-    residuals = Stream()
-    for station in {x.stats.station for x in spec_st.traces}:
+    residuals = SpectrumStream()
+    for station in {x.stats.station for x in spec_st}:
         spec_st_sel = spec_st.select(station=station)
-        for spec in spec_st_sel.traces:
+        for spec in spec_st_sel:
             if spec.stats.channel[-1] != 'H':
                 continue
 
-            xdata = spec.get_freq()
+            xdata = spec.freq
             synth_mean_mag = spectral_model(xdata, **sourcepar_summary)
 
             res = spec.copy()

--- a/sourcespec/ssp_util.py
+++ b/sourcespec/ssp_util.py
@@ -219,7 +219,7 @@ class MediumProperties():
             value = self.get_from_taup(mproperty)
             logger.info(
                 f'Using {mproperty} from global model (iasp91)')
-        return value
+        return float(value)
 
     def to_string(self, mproperty, value):
         """

--- a/sourcespec/ssp_wave_arrival.py
+++ b/sourcespec/ssp_wave_arrival.py
@@ -132,7 +132,8 @@ def _wave_arrival(trace, phase, config):
     # if _wave_arrival_taup() fails, it will raise a RuntimeError
     travel_time, takeoff_angle = _wave_arrival_taup(trace, phase)
     method = 'global velocity model (iasp91)'
-    return travel_time, takeoff_angle, method
+    # make sure returned values are float
+    return float(travel_time), float(takeoff_angle), method
 
 
 def _validate_pick(pick, theo_pick_time, tolerance, trace_id):

--- a/sourcespec_conda_env.yml
+++ b/sourcespec_conda_env.yml
@@ -12,7 +12,7 @@ dependencies:
   - obspy>=1.2.0
   - pyproj
   - tzlocal
-  - pyyaml
+  - pyyaml>=5.1
   - h5py
   - cartopy
   - nllgrid

--- a/sourcespec_conda_env.yml
+++ b/sourcespec_conda_env.yml
@@ -13,6 +13,7 @@ dependencies:
   - pyproj
   - tzlocal
   - pyyaml
+  - h5py
   - cartopy
   - nllgrid
   - pip


### PR DESCRIPTION
For an ongoing project, I need to save spectra to the output directory.

This motivated me to tackle the technical debt which was accumulating in the `Spectrum()` class.

This is the first class I wrote [12 years ago](https://github.com/SeismicSource/sourcespec/commit/47b34b41b612f976430dca34a59cf8db908f0aa4#diff-7a6e5a95180804a962b7400287af8d5a63272b17db533debe773c6897019cb12) (!) and at that time I decided that a quick and dirty –yet functional– solution was to make it inherit from ObsPy `Trace()` object.
One of the limits of this approach was that there wasn't any easy option (except of using `pickle`) to save spectra to disk.

So, I rewrote the `Spectrum()` class from scratch, while trying to keep the same interface of the previous one, with one difference:

- The method `Spectrum().get_freq()` does not exist anymore: it has been replaced by the class attribute `Spectrum().freq`. I chose indeed to store all the frequencies, and not only the starting frequency and the frequency delta. In this way, we have the same interface for `Spectrum().freq` and `Spectrum().freq_logspaced`.

The main improvements are the following:

- The new `Spectrum()` class, of course 😄 

- A new `SpectrumStream()` class, similar to ObsPy `Stream()`, to store `Spectrum()` objects. (Note that ObsPy `Stream()` will no longer accept `Spectrum()` objects, since they do not inherit anymore from `Trace()`).

- Both `Spectrum()` and `SpectrumStream()` have a `.write()` method to save the spectra to disk in `HDF5` or `TEXT` format. Both formats use YAML for serializing the metadata in `Spectrum().stats`.

- The new `HDF5` format is used for storing spectral residuals (replacing the `pickle` format).

- A new config option `save_spectra` (default: `False`) is introduced, to save spectra to the output dir.

- Finally, I added the function `read_spectra()` (similar to ObsPy `read()`) which will read an `HDF5` or `TEXT` file and return a `SpectrumStream()` with one or more `Spectrum()` objects.

I thoroughly tested these new classes with my default examples and with many other events: the results are consistent, with some small (~1%) differences arising sometimes, probably because of the different way frequencies are stored.

However, before merging this PR, I'm calling @krisvanneste and @rcabdia to kindly check that the new code does not introduce any regression in your use cases, since you are both using the SourceSpec API.

Thanks! ☺️
Claudio