### PR TITLE
Bugfix for r_power_n_segmented branch

### DIFF
--- a/sourcespec/config_files/configspec.conf
+++ b/sourcespec/config_files/configspec.conf
@@ -380,7 +380,7 @@ geom_spread_n_exponent = float(min=0, default=1)
 # The number of exponents must be equal to the number of distances.
 # Distances correspond to the start of each segment.
 # Note that no geometrical spreading correction is considered
-# below the smallest distance. This distance is generally set to 1.
+# below the smallest distance. This distance is generally set to 1 km.
 # Example:
 #   geom_spread_n_exponents = 1., 0., 0.5
 #   geom_spread_n_distances = 1, 70, 130

--- a/sourcespec/config_files/configspec.conf
+++ b/sourcespec/config_files/configspec.conf
@@ -379,8 +379,8 @@ geom_spread_n_exponent = float(min=0, default=1)
 # for the "r_power_n_segmented" geometrical spreading function.
 # The number of exponents must be one more than the number of distances.
 # Example:
-#   geom_spread_n_exponents = [1., 0., 0.5]
-#   geom_spread_n_distances = [70, 130]
+#   geom_spread_n_exponents = 1., 0., 0.5
+#   geom_spread_n_distances = 70, 130
 geom_spread_n_exponents = float_list(min=0, default=None)
 geom_spread_n_distances = float_list(default=None)
 # Geometrical spreading cutoff hypocentral distance, in km, for the

--- a/sourcespec/config_files/configspec.conf
+++ b/sourcespec/config_files/configspec.conf
@@ -375,14 +375,17 @@ geom_spread_model = option('r_power_n', 'r_power_n_segmented', 'boatwright', def
 #   geom_spread_n_exponent = 1 (default, body wave in a homogeneous full-space)
 #   geom_spread_n_exponent = 0.5 (surface wave in a homogeneous half-space)
 geom_spread_n_exponent = float(min=0, default=1)
-# Exponents and distances (in km) separating segments with different exponents
+# Exponents and hypocentral distances (in km) defining different segments
 # for the "r_power_n_segmented" geometrical spreading function.
-# The number of exponents must be one more than the number of distances.
+# The number of exponents must be equal to the number of distances.
+# Distances correspond to the start of each segment.
+# Note that no geometrical spreading correction is considered
+# below the smallest distance. This distance is generally set to 1.
 # Example:
 #   geom_spread_n_exponents = 1., 0., 0.5
-#   geom_spread_n_distances = 70, 130
+#   geom_spread_n_distances = 1, 70, 130
 geom_spread_n_exponents = float_list(min=0, default=None)
-geom_spread_n_distances = float_list(default=None)
+geom_spread_n_distances = float_list(min=0, default=None)
 # Geometrical spreading cutoff hypocentral distance, in km, for the
 # "boatwright" model:
 geom_spread_cutoff_distance = float(min=0.01, default=50)

--- a/sourcespec/ssp_build_spectra.py
+++ b/sourcespec/ssp_build_spectra.py
@@ -280,8 +280,8 @@ def _geometrical_spreading_coefficient(config, spec):
         if len(hinge_distances) != len(exponents):
             raise ValueError(
                 f'The number of exponents must be equal to the number of '
-                f'hinge distances. You provided {len(exponents)} exponents and '
-                f'{len(hinge_distances)} hinge distances'
+                f'hinge distances. You provided {len(exponents)} exponents '
+                f'and {len(hinge_distances)} hinge distances'
             )
         return geom_spread_r_power_n_segmented(hypo_dist_in_km, exponents,
                                                hinge_distances)

--- a/sourcespec/ssp_build_spectra.py
+++ b/sourcespec/ssp_build_spectra.py
@@ -277,9 +277,9 @@ def _geometrical_spreading_coefficient(config, spec):
     if config.geom_spread_model == 'r_power_n_segmented':
         exponents = config.geom_spread_n_exponents
         hinge_distances = config.geom_spread_n_distances
-        if len(hinge_distances) != len(exponents) - 1:
+        if len(hinge_distances) != len(exponents):
             raise ValueError(
-                f'The number of exponents must be one more than the number of '
+                f'The number of exponents must be equal to the number of '
                 f'hinge distances. You provided {len(exponents)} exponents and '
                 f'{len(hinge_distances)} hinge distances'
             )

--- a/sourcespec/ssp_util.py
+++ b/sourcespec/ssp_util.py
@@ -276,9 +276,9 @@ def geom_spread_r_power_n_segmented(hypo_dist_in_km, exponents,
     :param hypo_dist_in_km: Hypocentral distance (km).
     :type hypo_dist_in_km: float
     :param exponents: Exponents for different powerlaw segments
+    :type exponents: numpy.ndarray
+    :param hinge_distances: Distances defining start of powerlaw segments
     :type hinge_distances: numpy.ndarray
-    :param hinge_distances: Distances between different powerlaw segments
-    :type exponent: numpy.ndarray
     :return: Geometrical spreading correction (for distance in m)
     :rtype: float
     """
@@ -288,10 +288,8 @@ def geom_spread_r_power_n_segmented(hypo_dist_in_km, exponents,
     else:
         hypo_dist_in_km = np.asarray(hypo_dist_in_km, dtype='float')
         is_scalar = False
-    Rref = 1.
-    if hinge_distances is None:
-        hinge_distances = []
-    hinge_distances = np.hstack([[Rref], hinge_distances])
+    hinge_distances = np.asarray(hinge_distances)
+    Rref = hinge_distances[0]
     exponents = -np.asarray(exponents)
     # Do not allow distances less than Rref (1 km)
     hypo_dist_in_km = np.maximum(Rref, hypo_dist_in_km)

--- a/sourcespec/ssp_util.py
+++ b/sourcespec/ssp_util.py
@@ -289,7 +289,9 @@ def geom_spread_r_power_n_segmented(hypo_dist_in_km, exponents,
         hypo_dist_in_km = np.asarray(hypo_dist_in_km, dtype='float')
         is_scalar = False
     Rref = 1.
-    hinge_distances = np.hstack([[Rref], hinge_distances or []])
+    if hinge_distances is None:
+        hinge_distances = []
+    hinge_distances = np.hstack([[Rref], hinge_distances])
     exponents = -np.asarray(exponents)
     # Do not allow distances less than Rref (1 km)
     hypo_dist_in_km = np.maximum(Rref, hypo_dist_in_km)


### PR DESCRIPTION
Claudio,

I fixed the bug which I introduced in the `r_power_n_segmented` branch.
In order to catch the case where `hinge_distances` is None, I had written:
```
hinge_distances or []
```
which implies a comparison, which is not supported if `hinge_distances` is an array.

Now that this is fixed, I would like to ask your advice concerning the current design:
Currently, `hinge_distances` (corresponding to `geom_spread_n_distances` configuration parameter) only contains the distances separating the different segments, with the smallest allowed distance hard-coded to 1.
Do you agree with this or would you prefer to include the smallest distance in the list?