### PR TITLE
Catch runtime errors when smoothing spectra

### DIFF
--- a/sourcespec/ssp_build_spectra.py
+++ b/sourcespec/ssp_build_spectra.py
@@ -419,7 +419,13 @@ def _build_spectrum(config, trace):
     # for radiated_energy()
     spec.stats.coeff = coeff
     # smooth
-    _smooth_spectrum(spec, config.spectral_smooth_width_decades)
+    try:
+        _smooth_spectrum(spec, config.spectral_smooth_width_decades)
+    except Exception as e:
+        raise RuntimeError(
+            f'{spec.id}: Error smoothing spectrum: '
+            f'skipping spectrum\n{str(e)}'
+        ) from e
     return spec
 
 

--- a/sourcespec/ssp_build_spectra.py
+++ b/sourcespec/ssp_build_spectra.py
@@ -421,7 +421,7 @@ def _build_spectrum(config, trace):
     # smooth
     try:
         _smooth_spectrum(spec, config.spectral_smooth_width_decades)
-    except Exception as e:
+    except ValueError as e:
         raise RuntimeError(
             f'{spec.id}: Error smoothing spectrum: '
             f'skipping spectrum\n{str(e)}'


### PR DESCRIPTION
Small fix to avoid program ending when a runtime error occurs during smoothing of a spectrum.
I ran into this problem when running sourcespec on > 200 earthquakes.
It should be easy to propagate this fix to v2 as well.