### PR TITLE
rp_lower_bound

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,8 @@ Copyright (c) 2011-2025 Claudio Satriano <satriano@ipgp.fr>
 - New config parameters: `plot_map_geotiff_filepath`,
   `plot_map_geotiff_grayscale`, `plot_map_geotiff_attribution`
 - Improved documentation for the `sn_min` and `spectral_sn_min` parameters
+- New option `rp_lower_bound` to avoid overcorrection for stations close to a
+  nodal plane when radiation coefficient is computed from focal mechanism
 
 ### Bugfixes
 

--- a/sourcespec/config_files/configspec.conf
+++ b/sourcespec/config_files/configspec.conf
@@ -405,6 +405,9 @@ rps = float(min=0, default=0.62)
 #   Lg waves, surface waves at regional distances, depth phases at teleseismic
 #   distances)
 rp_from_focal_mechanism = boolean(default=False)
+# Lower bound on radiation pattern coefficient from focal mechanism
+# in order to avoid overestimated station magnitudes close to nodal planes
+rp_lower_bound = 0.01
 # "kp" and "ks" coefficients to compute source radius a from the P-wave
 # corner frequency fc_p or the S-wave corner frequency fc_s and the shear
 # wave speed beta ("vs_source"):

--- a/sourcespec/config_files/configspec.conf
+++ b/sourcespec/config_files/configspec.conf
@@ -407,7 +407,7 @@ rps = float(min=0, default=0.62)
 rp_from_focal_mechanism = boolean(default=False)
 # Lower bound on radiation pattern coefficient from focal mechanism
 # in order to avoid overestimated station magnitudes close to nodal planes
-rp_lower_bound = 0.01
+rp_lower_bound = float(min=0, default=0.01)
 # "kp" and "ks" coefficients to compute source radius a from the P-wave
 # corner frequency fc_p or the S-wave corner frequency fc_s and the shear
 # wave speed beta ("vs_source"):

--- a/sourcespec/ssp_radiation_pattern.py
+++ b/sourcespec/ssp_radiation_pattern.py
@@ -132,6 +132,8 @@ def get_radiation_pattern_coefficient(stats, config):
     # we are interested only in amplitude
     # (P, SV and SH radiation patterns have a sign)
     rp = abs(rp)
+    # Apply water level
+    rp = max(rp, config.rp_lower_bound)
     logger.info(
         f'{traceid}: {wave_type} radiation pattern from focal mechanism: '
         f'{rp:.2f}'


### PR DESCRIPTION
Small modification implementing a lower bound on the radiation pattern coefficient computed from focal mechanisms, in order to avoid overcorrection for stations close to a nodal plane.