### PR TITLE
Improve estimation of fc_0 for inverse frequency weighting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -79,6 +79,8 @@ Copyright (c) 2011-2025 Claudio Satriano <satriano@ipgp.fr>
   than 10 samples)
 - Fix for `sensitivity` config parameter always requiring a SAC file. Now, if
   `sensitivity` is a numerical value, any file format is accepted.
+- Improved estimation of `fc_0` (initial corner frequency) when inverse
+  frequency weighting is used
 
 ## v1.8 - 2024-04-07
 

--- a/sourcespec/ssp_inversion.py
+++ b/sourcespec/ssp_inversion.py
@@ -129,7 +129,12 @@ def _curve_fit(config, spec, weight, yerr, initial_values, bounds):
 
 
 def _freq_ranges_for_Mw0_and_tstar0(config, weight, freq_logspaced, statId):
-    """Find the frequency range to compute Mw_0 and, possibly, t_star_0."""
+    """
+    Find the frequency range to compute Mw_0 and, possibly, t_star_0.
+    Note that second index is supposed to correspond to fc_0, our initial
+    estimate of the corner frequency, which is essential in the inversion
+    procedure
+    """
     if config.weighting == 'noise':
         # we start where signal-to-noise becomes strong
         idx0 = np.where(weight > 0.5)[0][0]

--- a/sourcespec/ssp_inversion.py
+++ b/sourcespec/ssp_inversion.py
@@ -157,15 +157,16 @@ def _freq_ranges_for_Mw0_and_tstar0(config, weight, freq_logspaced, statId):
         # the closest index to f_weight:
         idx1 = np.where(freq_logspaced <= config.f_weight)[0][-1]
     elif config.weighting == 'inv_frequency':
-        weight_idxs = np.where(weight >= 0.7)[0]
-        try:
-            idx0 = weight_idxs[0]
-        except IndexError:
-            idx0 = 0
+        weight_idxs = np.where(weight >= 0.5)[0]
+        # max. weight is always at start of window
+        idx0 = 0
+        # index where weight is 0.5 or halfway, whichever comes first
         try:
             idx1 = weight_idxs[-1]
         except IndexError:
-            idx1 = len(weight) - 1
+            idx1 = len(weight) // 2
+        else:
+            idx1 = min(idx1, len(weight) // 2)
     else:
         idx0 = 0
         idx1 = len(weight) // 2


### PR DESCRIPTION
I noticed a lot of cases where spectra were skipped because the final corner frequency was too high compared to the initial estimate (`fc_0`). This estimate depends on the type of weighting used, in my case inverse frequency weighting. Lacking a better way to estimate corner frequency (maybe using maximum curvature?), I decreased the weight value that should correspond to `fc_0`, in combination with the constraint that it should be situated in the first half of the total fitting window. This has eliminated all `fc too high` cases in my test case.

Before:
![17540 ssp 00](https://github.com/user-attachments/assets/ada6bb26-8a6e-40ee-bac5-c6b77c774a37)

After:
![17540 ssp 00](https://github.com/user-attachments/assets/42fbeeba-d8be-4a94-b659-28875586f589)
