### PR TITLE
Config source falloff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,10 @@ previous versions. You will need to upgrade your old database manually or using
 - Possibility of specifying station-specific free-surface amplification factors
   (see [#81] and [#82])
 
+### Inversion
+
+- Configurable source spectral falloff power
+
 ### Post-Inversion
 
 - New config parameter `pi_fc_weight_min`, which defines the minimum acceptable
@@ -114,6 +118,7 @@ previous versions. You will need to upgrade your old database manually or using
 
 ### Config file
 
+- New config parameter: `source_falloff_power`
 - Consolidated seismic wave velocity and rock density parameters under the
   "EARTH MODEL PARAMETERS" section of the config file
 - `vp_tt` and `vs_tt` renamed to `vp` and `vs`; they can be lists to define a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,7 +82,7 @@ previous versions. You will need to upgrade your old database manually or using
 
 ### Inversion
 
-- Configurable source spectral falloff power
+- Configurable source spectral falloff power (see [#95] and [#96])
 
 ### Post-Inversion
 
@@ -933,3 +933,5 @@ Initial Python port.
 [#81]: https://github.com/SeismicSource/sourcespec/issues/81
 [#82]: https://github.com/SeismicSource/sourcespec/issues/82
 [#94]: https://github.com/SeismicSource/sourcespec/issues/94
+[#95]: https://github.com/SeismicSource/sourcespec/issues/95
+[#96]: https://github.com/SeismicSource/sourcespec/issues/96

--- a/docs/theoretical_background.rst
+++ b/docs/theoretical_background.rst
@@ -77,7 +77,7 @@ propagation term (geometric and anelastic attenuation of body waves):
           \times
           M_O
           \times
-          \frac{1}{1+\left(\frac{f}{f^{p|s}_c}\right)^2}
+          \frac{1}{1+\left(\frac{f}{f^{p|s}_c}\right)^n}
           \times
           e^{- \pi f t^*}
 
@@ -96,6 +96,8 @@ where:
 - :math:`M_O` is the seismic moment;
 - :math:`f` is the frequency;
 - :math:`f^{p|s}_c` is the corner frequency for P- or S-waves;
+- :math:`n` is the falloff power of the source spectrum (default is 2, for
+  Brune's source spectrum);
 - :math:`t^*` is an attenuation parameter which includes anelastic path
   attenuation (quality factor) and station-specific effects.
 
@@ -224,7 +226,7 @@ attenuation. This model is also converted in magnitude units:
           \frac{2}{3}
           \left[ \log_{10} \left(
                     M_O \times
-                    \frac{1}{1+\left(\frac{f}{f^{p|s}_c}\right)^2}
+                    \frac{1}{1+\left(\frac{f}{f^{p|s}_c}\right)^n}
                     \times
                     e^{- \pi f t^*}
                     \right) - 9.1 \right] =
@@ -232,7 +234,7 @@ attenuation. This model is also converted in magnitude units:
           =
           \frac{2}{3} \left( \log_{10} M_0 - 9.1 \right) +
           \frac{2}{3} \left[ \log_{10} \left(
-                    \frac{1}{1+\left(\frac{f}{f^{p|s}_c}\right)^2} \right) +
+                    \frac{1}{1+\left(\frac{f}{f^{p|s}_c}\right)^n} \right) +
                     \log_{10} \left( e^{- \pi f t^*} \right)
                     \right]
 
@@ -244,7 +246,7 @@ Finally coming to the following model used for the inversion:
    Y^{p|s}(f) =
           M_w +
           \frac{2}{3} \left[ - \log_{10} \left(
-                    1+\left(\frac{f}{f^{p|s}_c}\right)^2 \right) -
+                    1+\left(\frac{f}{f^{p|s}_c}\right)^n \right) -
                     \pi \, f t^* \log_{10} e
                     \right]
 
@@ -475,11 +477,13 @@ between the estimated radiated energy and the true radiated energy, defined as:
   R = \frac{2}{\pi}
     \left[
       \arctan(f_{max}/f^{p|s}_c) -
-      \frac{f_{max}/f^{p|s}_c}{1+(f_{max}/f^{p|s}_c)^2}
+      \frac{f_{max}/f^{p|s}_c}{1+(f_{max}/f^{p|s}_c)^n}
     \right]
 
 where :math:`f_{max}` is the maximum frequency used to compute the energy
-integral and :math:`f^{p|s}_c` is the P- or S-wave corner frequency.
+integral, :math:`f^{p|s}_c` is the P- or S-wave corner frequency and
+:math:`n` is the falloff power of the source spectrum (default is 2, for
+Brune's source spectrum).
 
 The values of R range between 0 (for :math:`f_{max}/f^{p|s}_c \to 0`) and 1
 (for :math:`f_{max}/f^{p|s}_c \to \infty`).

--- a/sourcespec/config_files/configspec.conf
+++ b/sourcespec/config_files/configspec.conf
@@ -487,6 +487,9 @@ rp_lower_bound = float(min=0, default=0.01)
 #   S&H: Sato and Hirasawa (1973)
 kp = float(min=0, default=0.38)
 ks = float(min=0, default=0.3724)
+# Falloff power of source spectrum.
+# Default (2) corresponds to Brune (1970) source spectrum
+source_falloff_power = float(min=0, default=2)
 # -------- SPECTRAL MODEL PARAMETERS
 
 

--- a/sourcespec/source_model.py
+++ b/sourcespec/source_model.py
@@ -58,11 +58,13 @@ def make_synth(config, spec_st, trace_spec=None):
         # spec.data and spec.data_logspaced have to be set before
         # spec.data_mag and spec.data_mag_logspaced, so that the Spectrum
         # object can check for consistency
-        data_mag = spectral_model(freq, mag, fc, t_star, alpha)
+        data_mag = spectral_model(freq, mag, fc, t_star, alpha,
+                                  n=config.source_falloff_power)
         spec.data = mag_to_moment(data_mag)
         spec.data_mag = data_mag
         data_mag_logspaced = spectral_model(
-            freq_logspaced, mag, fc, t_star, alpha)
+            freq_logspaced, mag, fc, t_star, alpha,
+            n=config.source_falloff_power)
         spec.data_logspaced = mag_to_moment(data_mag_logspaced)
         spec.data_mag_logspaced = data_mag_logspaced
         spec_st.append(spec)

--- a/sourcespec/ssp_inversion.py
+++ b/sourcespec/ssp_inversion.py
@@ -649,11 +649,11 @@ def _synth_spec(config, spec, station_pars):
     spec_synth.stats.channel = f'{chan_no_orientation}S'
     spec_synth.stats.par = par
     spec_synth.stats.par_err = par_err
-    spec_synth.data_mag = spectral_model(freq, *params_opt,
-                                         n=config.source_falloff_power)
+    spec_synth.data_mag = spectral_model(
+        freq, *params_opt, n=config.source_falloff_power)
     spec_synth.data = mag_to_moment(spec_synth.data_mag)
-    spec_synth.data_mag_logspaced = spectral_model(freq_logspaced, *params_opt,
-                                                n=config.source_falloff_power)
+    spec_synth.data_mag_logspaced = spectral_model(
+        freq_logspaced, *params_opt, n=config.source_falloff_power)
     spec_synth.data_logspaced = mag_to_moment(spec_synth.data_mag_logspaced)
     spec_st.append(spec_synth)
 
@@ -663,14 +663,13 @@ def _synth_spec(config, spec, station_pars):
         spec_synth.stats.channel = f'{chan_no_orientation}s'
         _params = list(params_opt)
         _params[-1] = 0
-        spec_synth.data_mag = spectral_model(freq, *_params,
-                                            n=config.source_falloff_power)
+        spec_synth.data_mag = spectral_model(
+            freq, *_params, n=config.source_falloff_power)
         spec_synth.data = mag_to_moment(spec_synth.data_mag)
-        spec_synth.data_mag_logspaced =\
-            spectral_model(freq_logspaced, *_params,
-                           n=config.source_falloff_power)
-        spec_synth.data_logspaced =\
-            mag_to_moment(spec_synth.data_mag_logspaced)
+        spec_synth.data_mag_logspaced = spectral_model(
+            freq_logspaced, *_params, n=config.source_falloff_power)
+        spec_synth.data_logspaced = mag_to_moment(
+            spec_synth.data_mag_logspaced)
         spec_st.append(spec_synth)
 
     # Add an extra spectrum with no corner frequency
@@ -679,14 +678,14 @@ def _synth_spec(config, spec, station_pars):
         spec_synth.stats.channel = f'{chan_no_orientation}t'
         _params = list(params_opt)
         _params[1] = 1e999
-        spec_synth.data_mag = spectral_model(freq, *_params,
-                                             n=config.source_falloff_power)
+        spec_synth.data_mag = spectral_model(
+            freq, *_params, n=config.source_falloff_power)
         spec_synth.data = mag_to_moment(spec_synth.data_mag)
         spec_synth.data_mag_logspaced =\
-            spectral_model(freq_logspaced, *_params,
-                           n=config.source_falloff_power)
-        spec_synth.data_logspaced =\
-            mag_to_moment(spec_synth.data_mag_logspaced)
+            spectral_model(
+                freq_logspaced, *_params, n=config.source_falloff_power)
+        spec_synth.data_logspaced = mag_to_moment(
+            spec_synth.data_mag_logspaced)
         spec_st.append(spec_synth)
     return spec_st
 

--- a/sourcespec/ssp_inversion.py
+++ b/sourcespec/ssp_inversion.py
@@ -19,6 +19,7 @@ import logging
 import contextlib
 import math
 import numpy as np
+from functools import partial
 from scipy.optimize import curve_fit, minimize, basinhopping
 from scipy.signal import argrelmax
 from obspy.geodetics import gps2dist_azimuth
@@ -144,6 +145,8 @@ def _curve_fit(
     freq_logspaced = spec.freq_logspaced
     ydata = spec.data_mag_logspaced
 
+    spectral_model_n = partial(spectral_model, n=config.source_falloff_power)
+
     # Define t_star function if Q_model is provided
     if Q_model is not None:
         # compute t_star from Q_model and travel time
@@ -154,10 +157,10 @@ def _curve_fit(
             return travel_time / _Q_model
 
         def _spectral_model(freq, Mw, fc):
-            return spectral_model(freq, Mw, fc, t_star)
+            return spectral_model_n(freq, Mw, fc, t_star)
     else:
         t_star = None
-        _spectral_model = spectral_model
+        _spectral_model = spectral_model_n
 
     # Add t_star_model to spec stats for later use
     spec.stats.t_star_model = t_star
@@ -400,7 +403,8 @@ def _spec_inversion(config, spec, spec_weight, station_pars, Q_model=None):
         # fit t_star_0 and Mw on the initial part of the spectrum,
         # corrected for the effect of fc
         ydata_corr =\
-            ydata - spectral_model(freq_logspaced, Mw=0, fc=fc_0, t_star=0)
+            ydata - spectral_model(freq_logspaced, Mw=0, fc=fc_0, t_star=0,
+                                   n=config.source_falloff_power)
         ydata_corr = smooth(ydata_corr, window_len=18)
         slope, Mw_0 = np.polyfit(
             freq_logspaced[idx0: idx1], ydata_corr[idx0: idx1], deg=1)
@@ -645,9 +649,11 @@ def _synth_spec(config, spec, station_pars):
     spec_synth.stats.channel = f'{chan_no_orientation}S'
     spec_synth.stats.par = par
     spec_synth.stats.par_err = par_err
-    spec_synth.data_mag = spectral_model(freq, *params_opt)
+    spec_synth.data_mag = spectral_model(freq, *params_opt,
+                                         n=config.source_falloff_power)
     spec_synth.data = mag_to_moment(spec_synth.data_mag)
-    spec_synth.data_mag_logspaced = spectral_model(freq_logspaced, *params_opt)
+    spec_synth.data_mag_logspaced = spectral_model(freq_logspaced, *params_opt,
+                                                n=config.source_falloff_power)
     spec_synth.data_logspaced = mag_to_moment(spec_synth.data_mag_logspaced)
     spec_st.append(spec_synth)
 
@@ -657,10 +663,12 @@ def _synth_spec(config, spec, station_pars):
         spec_synth.stats.channel = f'{chan_no_orientation}s'
         _params = list(params_opt)
         _params[-1] = 0
-        spec_synth.data_mag = spectral_model(freq, *_params)
+        spec_synth.data_mag = spectral_model(freq, *_params,
+                                            n=config.source_falloff_power)
         spec_synth.data = mag_to_moment(spec_synth.data_mag)
         spec_synth.data_mag_logspaced =\
-            spectral_model(freq_logspaced, *_params)
+            spectral_model(freq_logspaced, *_params,
+                           n=config.source_falloff_power)
         spec_synth.data_logspaced =\
             mag_to_moment(spec_synth.data_mag_logspaced)
         spec_st.append(spec_synth)
@@ -671,10 +679,12 @@ def _synth_spec(config, spec, station_pars):
         spec_synth.stats.channel = f'{chan_no_orientation}t'
         _params = list(params_opt)
         _params[1] = 1e999
-        spec_synth.data_mag = spectral_model(freq, *_params)
+        spec_synth.data_mag = spectral_model(freq, *_params,
+                                             n=config.source_falloff_power)
         spec_synth.data = mag_to_moment(spec_synth.data_mag)
         spec_synth.data_mag_logspaced =\
-            spectral_model(freq_logspaced, *_params)
+            spectral_model(freq_logspaced, *_params,
+                           n=config.source_falloff_power)
         spec_synth.data_logspaced =\
             mag_to_moment(spec_synth.data_mag_logspaced)
         spec_st.append(spec_synth)

--- a/sourcespec/ssp_radiated_energy.py
+++ b/sourcespec/ssp_radiated_energy.py
@@ -108,7 +108,7 @@ def _radiated_energy_coefficient(rho, vel, free_surf_ampl, rp, average_rp):
     return 8 * np.pi * c_coeff**2 * rho * vel
 
 
-def _finite_bandwidth_correction(spec, fc, fmax):
+def _finite_bandwidth_correction(spec, fc, fmax, n=2):
     """
     Compute finite bandwidth correction.
 
@@ -119,12 +119,16 @@ def _finite_bandwidth_correction(spec, fc, fmax):
     - Di Bona & Rovelli (1988), eq. 13
     - Ide & Beroza (2001), eq. 5
     - Lancieri et al. (2012), eq. 4 (note, missing parenthesis in the paper)
+
+    Note:
+    Here we add a new parameter n, which is the falloff power of the source
+    spectrum. Default is n=2, corresponding to the Brune source spectrum.
     """
     if fmax is None:
         fmax = spec.freq[-1]
     return (
         2. / np.pi *
-        (np.arctan2(fmax, fc) - (fmax / fc) / (1 + (fmax / fc)**2.))
+        (np.arctan2(fmax, fc) - (fmax / fc) / (1 + (fmax / fc)**n))
     )
 
 
@@ -238,7 +242,8 @@ def radiated_energy_and_apparent_stress(
                 'than signal energy: skipping spectrum.')
             continue
 
-        R = _finite_bandwidth_correction(spec, fc, fmax)
+        R = _finite_bandwidth_correction(
+            spec, fc, fmax, n=config.source_falloff_power)
         Er /= R
         # Store the Er value into the StationParameter() object
         param_Er.value = Er

--- a/sourcespec/ssp_residuals.py
+++ b/sourcespec/ssp_residuals.py
@@ -49,7 +49,8 @@ def spectral_residuals(config, spec_st, sspec_output):
             if spec.stats.ignore:
                 continue
             xdata = spec.freq
-            synth_mean_mag = spectral_model(xdata, **sourcepar_summary)
+            synth_mean_mag = spectral_model(xdata, **sourcepar_summary,
+                                            n=config.source_falloff_power)
             res = spec.copy()
             # remove existing data
             del res.data

--- a/sourcespec/ssp_spectral_model.py
+++ b/sourcespec/ssp_spectral_model.py
@@ -19,7 +19,7 @@ import math
 import numpy as np
 
 
-def spectral_model(freq, Mw, fc, t_star, alpha=1.):
+def spectral_model(freq, Mw, fc, t_star, n=2, alpha=1.):
     r"""
     Spectral model for seismic source spectrum.
 
@@ -29,7 +29,7 @@ def spectral_model(freq, Mw, fc, t_star, alpha=1.):
     .. math::
 
         Y_{data} = M_w + \frac{2}{3} \left[ - \log_{10} \left(
-                              1+\left(\frac{f}{f_c}\right)^2 \right) -
+                              1+\left(\frac{f}{f_c}\right)^n \right) -
                               \pi \, f^\alpha t^*(f) \log_{10} e \right]
 
     See :ref:`Theoretical Background <theoretical_background>`
@@ -47,6 +47,9 @@ def spectral_model(freq, Mw, fc, t_star, alpha=1.):
          Attenuation parameter t* (in seconds), equal to travel time divided
          by quality factor (tt/Q). Can be a constant value or a function of
          frequency.
+    n : float
+        Falloff power of source spectrum
+        (default: 2 = Brune source spectrum)
     alpha : float, optional
          Frequency exponent for the attenuation term. Default is 1.0 for
          standard attenuation model.
@@ -65,7 +68,7 @@ def spectral_model(freq, Mw, fc, t_star, alpha=1.):
     t_star_val = t_star(freq) if callable(t_star) else t_star
     return (
         Mw -
-        (2. / 3.) * np.log10(1. + np.power((freq / fc), 2)) -
+        (2. / 3.) * np.log10(1. + np.power((freq / fc), n)) -
         (2. / 3.) * loge * (math.pi * np.power(freq, alpha) * t_star_val)
     )
 

--- a/sourcespec/ssp_spectral_model.py
+++ b/sourcespec/ssp_spectral_model.py
@@ -48,8 +48,8 @@ def spectral_model(freq, Mw, fc, t_star, n=2, alpha=1.):
          by quality factor (tt/Q). Can be a constant value or a function of
          frequency.
     n : float
-        Falloff power of source spectrum
-        (default: 2 = Brune source spectrum)
+         Falloff power of source spectrum. Default is 2, corresponding to the
+         Brune source spectrum.
     alpha : float, optional
          Frequency exponent for the attenuation term. Default is 1.0 for
          standard attenuation model.
@@ -60,9 +60,6 @@ def spectral_model(freq, Mw, fc, t_star, n=2, alpha=1.):
          Logarithmic spectral amplitude(s) at the specified
          frequency/frequencies.
     """
-    # log S(w)= log(coeff*Mo) + log((1/(1+(w/wc)^2)) + \
-    #           log (exp (- w *t_star/2))
-    # attenuation model: exp[-pi t* f] with t*=T /Q
     loge = math.log10(math.e)
     # Check if t_star is callable (function) or a constant
     t_star_val = t_star(freq) if callable(t_star) else t_star

--- a/sourcespec/ssp_summary_statistics.py
+++ b/sourcespec/ssp_summary_statistics.py
@@ -394,7 +394,7 @@ def compute_summary_statistics(config, sspec_output, spec_st, weight_st):
     logger.info(f'params_percentiles: {sourcepar_percentiles}')
 
     # Add synthetic spectra for summary statistics
-    _add_summary_spectra(sspec_output, spec_st)
+    _add_summary_spectra(sspec_output, spec_st, config)
     # Compute dispersion around the summary synthetic spectrum
     logger.info(
         'Computing dispersion around the summary synthetic spectrum...')

--- a/sourcespec/ssp_summary_statistics.py
+++ b/sourcespec/ssp_summary_statistics.py
@@ -172,20 +172,22 @@ def _param_summary_statistics(
     return summary
 
 
-def _make_summary_spec(station, channel, freq_logspaced, Mw, fc, t_star):
+def _make_summary_spec(station, channel, freq_logspaced, Mw, fc, t_star,
+                       config):
     """Create a synthetic spectrum for summary statistics."""
     sp = Spectrum()
     sp.stats.station = station
     sp.stats.channel = channel
     sp.freq_logspaced = freq_logspaced
-    data_mag_logspaced = spectral_model(freq_logspaced, Mw, fc, t_star)
+    data_mag_logspaced = spectral_model(freq_logspaced, Mw, fc, t_star,
+                                        n=config.source_falloff_power)
     # data_logspaced must be provided before data_mag_logspaced
     sp.data_logspaced = mag_to_moment(data_mag_logspaced)
     sp.data_mag_logspaced = data_mag_logspaced
     return sp
 
 
-def _add_summary_spectra(sspec_output, spec_st):
+def _add_summary_spectra(sspec_output, spec_st, config):
     """Add to the spectra stream synthetic spectra for summary statistics."""
     fmins = [np.nanmin(spec.freq) for spec in spec_st]
     fmaxs = [np.nanmax(spec.freq) for spec in spec_st]
@@ -204,13 +206,15 @@ def _add_summary_spectra(sspec_output, spec_st):
             t_star = t_star_model
             break
     spec_st.append(
-        _make_summary_spec('SUMMARY', 'SSS', freq_logspaced, Mw, fc, t_star)
+        _make_summary_spec('SUMMARY', 'SSS', freq_logspaced, Mw, fc, t_star,
+                           config)
     )
     spec_st.append(
-        _make_summary_spec('SUMMARY', 'SSs', freq_logspaced, Mw, fc, 0)
+        _make_summary_spec('SUMMARY', 'SSs', freq_logspaced, Mw, fc, 0, config)
     )
     spec_st.append(
-        _make_summary_spec('SUMMARY', 'SSt', freq_logspaced, Mw, 1e999, t_star)
+        _make_summary_spec('SUMMARY', 'SSt', freq_logspaced, Mw, 1e999, t_star,
+                           config)
     )
 
 

--- a/sourcespec/ssp_summary_statistics.py
+++ b/sourcespec/ssp_summary_statistics.py
@@ -179,8 +179,8 @@ def _make_summary_spec(station, channel, freq_logspaced, Mw, fc, t_star,
     sp.stats.station = station
     sp.stats.channel = channel
     sp.freq_logspaced = freq_logspaced
-    data_mag_logspaced = spectral_model(freq_logspaced, Mw, fc, t_star,
-                                        n=config.source_falloff_power)
+    data_mag_logspaced = spectral_model(
+        freq_logspaced, Mw, fc, t_star, n=config.source_falloff_power)
     # data_logspaced must be provided before data_mag_logspaced
     sp.data_logspaced = mag_to_moment(data_mag_logspaced)
     sp.data_mag_logspaced = data_mag_logspaced
@@ -206,15 +206,15 @@ def _add_summary_spectra(sspec_output, spec_st, config):
             t_star = t_star_model
             break
     spec_st.append(
-        _make_summary_spec('SUMMARY', 'SSS', freq_logspaced, Mw, fc, t_star,
-                           config)
+        _make_summary_spec(
+            'SUMMARY', 'SSS', freq_logspaced, Mw, fc, t_star, config)
     )
     spec_st.append(
         _make_summary_spec('SUMMARY', 'SSs', freq_logspaced, Mw, fc, 0, config)
     )
     spec_st.append(
-        _make_summary_spec('SUMMARY', 'SSt', freq_logspaced, Mw, 1e999, t_star,
-                           config)
+        _make_summary_spec(
+            'SUMMARY', 'SSt', freq_logspaced, Mw, 1e999, t_star, config)
     )
 
 


### PR DESCRIPTION
This branch allows to configure source spectral falloff through a new `source_falloff_power` configuration option.
It also contains a bugfix in the `_interpolate_data_to_new_freq` function in `spectrum.py`.